### PR TITLE
fix stack settings

### DIFF
--- a/quickstart/101-web-app-linux-java/app_service.tf
+++ b/quickstart/101-web-app-linux-java/app_service.tf
@@ -22,8 +22,6 @@ resource "azurerm_app_service" "default" {
 
   site_config {
     always_on        = true
-    java_version           = "1.8"
-    java_container         = "tomcat"
-    java_container_version = "9.0"
+    linux_fx_version = "TOMCAT|8.5-java11"
   }
 }


### PR DESCRIPTION
Using the linux app service plan, the stack settings will be empty if we use the site config. We should use linux_fx_version.

Before : 
![tf_bug](https://user-images.githubusercontent.com/42579419/68543295-88f5de80-03b5-11ea-9147-c95f083239c2.png)

After: 
![tf_correct](https://user-images.githubusercontent.com/42579419/68543302-957a3700-03b5-11ea-9c79-50461f73ab4f.png)

