### PR TITLE
Corrects and fixes AKS TF quickstart templates

### DIFF
--- a/quickstart/201-aks-acr-identity/aks.tf
+++ b/quickstart/201-aks-acr-identity/aks.tf
@@ -3,7 +3,6 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = "${azurerm_resource_group.default.location}"
   resource_group_name = "${azurerm_resource_group.default.name}"
   dns_prefix          = "${var.dns_prefix}-${var.name}-aks-${var.environment}"
-  depends_on          = ["azurerm_role_assignment.aks_network", "azurerm_role_assignment.aks_acr"]
 
   agent_pool_profile {
     name            = "default"

--- a/quickstart/201-aks-acr-identity/azuread.tf
+++ b/quickstart/201-aks-acr-identity/azuread.tf
@@ -18,7 +18,7 @@ resource "azuread_service_principal_password" "default" {
 }
 
 resource "azurerm_role_assignment" "aks_acr" {
-  scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}/providers/Microsoft.ContainerRegistry/registries/${azurerm_container_registry.default.name}"
+  scope                = "${azurerm_container_registry.default.id}"
   role_definition_name = "AcrPull"
   principal_id         = "${azuread_service_principal.default.id}"
 }

--- a/quickstart/201-aks-acr-identity/azuread.tf
+++ b/quickstart/201-aks-acr-identity/azuread.tf
@@ -19,6 +19,6 @@ resource "azuread_service_principal_password" "default" {
 
 resource "azurerm_role_assignment" "aks_acr" {
   scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}/providers/Microsoft.ContainerRegistry/registries/${azurerm_container_registry.default.name}"
-  role_definition_name = "Reader"
+  role_definition_name = "AcrPull"
   principal_id         = "${azuread_service_principal.default.id}"
 }

--- a/quickstart/201-aks-acr-identity/azuread.tf
+++ b/quickstart/201-aks-acr-identity/azuread.tf
@@ -17,12 +17,6 @@ resource "azuread_service_principal_password" "default" {
   end_date             = "2099-01-01T01:00:00Z"
 }
 
-resource "azurerm_role_assignment" "aks_network" {
-  scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}"
-  role_definition_name = "Network Contributor"
-  principal_id         = "${azuread_service_principal.default.id}"
-}
-
 resource "azurerm_role_assignment" "aks_acr" {
   scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}/providers/Microsoft.ContainerRegistry/registries/${azurerm_container_registry.default.name}"
   role_definition_name = "Reader"

--- a/quickstart/201-aks-acr-identity/main.tf
+++ b/quickstart/201-aks-acr-identity/main.tf
@@ -8,9 +8,6 @@ provider "azuread" {
   version = "=0.6.0"
 }
 
-# Reference to the current subscription.  Used when creating role assignments
-data "azurerm_subscription" "current" {}
-
 # The main resource group for this deployment
 resource "azurerm_resource_group" "default" {
   name     = "${var.name}-${var.environment}-rg"

--- a/quickstart/201-aks-acr-identity/readme.md
+++ b/quickstart/201-aks-acr-identity/readme.md
@@ -1,6 +1,6 @@
-# AKC + ACR with Managed Identity
+# AKC + ACR with Service Principal
 
-This template deploys an Azure Kubernetes Service cluster with a user-assigned Identity along with an Azure Container Registry.  The identity of the AKS cluster has an assigned reader role to the ACR instance so AKS can pull containers without needing to have a Docker username and password configured.
+This template deploys an Azure Kubernetes Service cluster with a service principal along with an Azure Container Registry.  The identity of the AKS cluster has an assigned AcrPull role to the ACR instance so AKS can pull containers without needing to have a Docker username and password configured.
 
 ## Variables
 

--- a/quickstart/201-aks-helm/aks.tf
+++ b/quickstart/201-aks-helm/aks.tf
@@ -3,7 +3,6 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = "${azurerm_resource_group.default.location}"
   resource_group_name = "${azurerm_resource_group.default.name}"
   dns_prefix          = "${var.dns_prefix}-${var.name}-aks-${var.environment}"
-  depends_on          = ["azurerm_role_assignment.default"]
 
   agent_pool_profile {
     name            = "default"

--- a/quickstart/201-aks-helm/azuread.tf
+++ b/quickstart/201-aks-helm/azuread.tf
@@ -16,9 +16,3 @@ resource "azuread_service_principal_password" "default" {
   value                = "${random_string.password.result}"
   end_date             = "2099-01-01T01:00:00Z"
 }
-
-resource "azurerm_role_assignment" "default" {
-  scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}"
-  role_definition_name = "Network Contributor"
-  principal_id         = "${azuread_service_principal.default.id}"
-}

--- a/quickstart/201-aks-helm/main.tf
+++ b/quickstart/201-aks-helm/main.tf
@@ -8,9 +8,6 @@ provider "azuread" {
   version = "=0.6.0"
 }
 
-# Reference to the current subscription.  Used when creating role assignments
-data "azurerm_subscription" "current" {}
-
 # The main resource group for this deployment
 resource "azurerm_resource_group" "default" {
   name     = "${var.name}-${var.environment}-rg"

--- a/quickstart/201-aks-log-analytics/aks.tf
+++ b/quickstart/201-aks-log-analytics/aks.tf
@@ -3,7 +3,6 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = "${azurerm_resource_group.default.location}"
   resource_group_name = "${azurerm_resource_group.default.name}"
   dns_prefix          = "${var.dns_prefix}-${var.name}-aks-${var.environment}"
-  depends_on          = ["azurerm_role_assignment.default"]
 
   agent_pool_profile {
     name            = "default"

--- a/quickstart/201-aks-log-analytics/azuread.tf
+++ b/quickstart/201-aks-log-analytics/azuread.tf
@@ -16,9 +16,3 @@ resource "azuread_service_principal_password" "default" {
   value                = "${random_string.password.result}"
   end_date             = "2099-01-01T01:00:00Z"
 }
-
-resource "azurerm_role_assignment" "default" {
-  scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}"
-  role_definition_name = "Network Contributor"
-  principal_id         = "${azuread_service_principal.default.id}"
-}

--- a/quickstart/201-aks-log-analytics/main.tf
+++ b/quickstart/201-aks-log-analytics/main.tf
@@ -8,9 +8,6 @@ provider "azuread" {
   version = "=0.6.0"
 }
 
-# Reference to the current subscription.  Used when creating role assignments
-data "azurerm_subscription" "current" {}
-
 # The main resource group for this deployment
 resource "azurerm_resource_group" "default" {
   name     = "${var.name}-${var.environment}-rg"

--- a/quickstart/201-aks-rbac-dashboard-admin/aks.tf
+++ b/quickstart/201-aks-rbac-dashboard-admin/aks.tf
@@ -3,7 +3,6 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = "${azurerm_resource_group.default.location}"
   resource_group_name = "${azurerm_resource_group.default.name}"
   dns_prefix          = "${var.dns_prefix}-${var.name}-aks-${var.environment}"
-  depends_on          = ["azurerm_role_assignment.default"]
 
   agent_pool_profile {
     name            = "default"

--- a/quickstart/201-aks-rbac-dashboard-admin/azuread.tf
+++ b/quickstart/201-aks-rbac-dashboard-admin/azuread.tf
@@ -16,9 +16,3 @@ resource "azuread_service_principal_password" "default" {
   value                = "${random_string.password.result}"
   end_date             = "2099-01-01T01:00:00Z"
 }
-
-resource "azurerm_role_assignment" "default" {
-  scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}"
-  role_definition_name = "Network Contributor"
-  principal_id         = "${azuread_service_principal.default.id}"
-}

--- a/quickstart/201-aks-rbac-dashboard-admin/main.tf
+++ b/quickstart/201-aks-rbac-dashboard-admin/main.tf
@@ -8,9 +8,6 @@ provider "azuread" {
   version = "=0.6.0"
 }
 
-# Reference to the current subscription.  Used when creating role assignments
-data "azurerm_subscription" "current" {}
-
 # The main resource group for this deployment
 resource "azurerm_resource_group" "default" {
   name     = "${var.name}-${var.environment}-rg"

--- a/quickstart/201-aks-rbac-dashboard-admin/readme.md
+++ b/quickstart/201-aks-rbac-dashboard-admin/readme.md
@@ -1,7 +1,7 @@
 # AKS with an Admin Dashboard
 
 
-This template deploys an [Azure Kubernetes Service](https://www.terraform.io/docs/providers/azurerm/r/kubernetes_cluster.html) instance with Role Based Access Control (RBAC) enabled. With this, by default the robust Kubernetes dashboard has no rights to view or make changes to the cluster. In this template we leverage the Kubernetes provider to provision a role binding for the Dashboard accoutn to give it `cluster-admin` rights - something we shoudl not do in production but can be very useful in development. 
+This template deploys an [Azure Kubernetes Service](https://www.terraform.io/docs/providers/azurerm/r/kubernetes_cluster.html) instance with Role Based Access Control (RBAC) enabled. With this, by default the robust Kubernetes dashboard has no rights to view or make changes to the cluster. In this template we leverage the Kubernetes provider to provision a role binding for the Dashboard account to give it `cluster-admin` rights - something we should not do in production but can be very useful in development.
 
 ## Resources
 


### PR DESCRIPTION
This PR removes some unnecessary RBAC role assignments that are incorrect, when applied. Wrong RG level and overall not needed for an AKS cluster deployment without the Advanced Networking option.

Furthermore, correcting the README for `201-aks-acr-identity` that stated using Managed Identity, but only makes use of an Azure Service Principal. As well adjusting the RBAC role assignment for the ACR. 

Never seen a scope argument to be build like this:
```
scope = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}/providers/Microsoft.ContainerRegistry/registries/${azurerm_container_registry.default.name}"
```

Best practice and designed way to do it in TF:
```
scope = "${azurerm_container_registry.default.id}"
```