### PR TITLE
Replacing Reader with AcrPull in azurerm_role_assignment.aks_acr

### DIFF
--- a/quickstart/201-aks-acr-identity/azuread.tf
+++ b/quickstart/201-aks-acr-identity/azuread.tf
@@ -25,6 +25,6 @@ resource "azurerm_role_assignment" "aks_network" {
 
 resource "azurerm_role_assignment" "aks_acr" {
   scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${azurerm_resource_group.default.name}/providers/Microsoft.ContainerRegistry/registries/${azurerm_container_registry.default.name}"
-  role_definition_name = "Reader"
+  role_definition_name = "AcrPull"
   principal_id         = "${azuread_service_principal.default.id}"
 }


### PR DESCRIPTION
Aks doesn't need Reader role on the acr, AcrPull is enough