### PR TITLE
Always use the latest version of Checkov

### DIFF
--- a/samples/integration-testing/src/checkov.sh
+++ b/samples/integration-testing/src/checkov.sh
@@ -22,7 +22,7 @@ WORK_DIR=${1-$(pwd)}
 #######################################
 run_checkov() {
   local test_dir=$1
-  docker run -t -v "${test_dir}":/tf bridgecrew/checkov:release-1.0.235 -d /tf
+  docker run -t -v "${test_dir}":/tf bridgecrew/checkov:latest -d /tf
 }
 
 #######################################


### PR DESCRIPTION
For inclusion of new builtin checks.

Fixes issue #57 