### PR TITLE
Fix resource TYPOs in variables

### DIFF
--- a/quickstart/101-web-app-linux-container/variables.tf
+++ b/quickstart/101-web-app-linux-container/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart/101-web-app-linux-java/variables.tf
+++ b/quickstart/101-web-app-linux-java/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart/101-web-app-windows-dotnet/variables.tf
+++ b/quickstart/101-web-app-windows-dotnet/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart/201-web-app-docker-acr/variables.tf
+++ b/quickstart/201-web-app-docker-acr/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 


### PR DESCRIPTION
This should include all misspellings of 'resoruce'