### PR TITLE
Update example link for Mysql FS

### DIFF
--- a/quickstart/201-mysql-fs-db/readme.md
+++ b/quickstart/201-mysql-fs-db/readme.md
@@ -24,4 +24,4 @@ This template deploys an [Azure MySQL Flexible Server Database](https://registry
 
 ## Example
 
-To see how to run this example, see [Create an Azure MySQL Flexible Server Database using Terraform](https://docs.microsoft.com/azure/developer/terraform/deploy-mysql-flexible-server-database).
+To see how to run this example, see [Create an Azure MySQL Flexible Server Database using Terraform](https://docs.microsoft.com/azure/mysql/flexible-server/quickstart-create-terraform).


### PR DESCRIPTION
As the terraform doc about MySql FS DB is moved to Mysql Service Developer Center, so the example link in terraform doc for mysql fs db also need to be updated.