### PR TITLE
Explicitly disable storage blob public access for workspace templates

### DIFF
--- a/quickstart/101-machine-learning/workspace.tf
+++ b/quickstart/101-machine-learning/workspace.tf
@@ -21,6 +21,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_container_registry" "default" {

--- a/quickstart/101-machine-learning/workspace.tf
+++ b/quickstart/101-machine-learning/workspace.tf
@@ -16,11 +16,11 @@ resource "azurerm_key_vault" "default" {
 }
 
 resource "azurerm_storage_account" "default" {
-  name                     = "st${var.name}${var.environment}"
-  location                 = azurerm_resource_group.default.location
-  resource_group_name      = azurerm_resource_group.default.name
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
+  name                            = "st${var.name}${var.environment}"
+  location                        = azurerm_resource_group.default.location
+  resource_group_name             = azurerm_resource_group.default.name
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
   allow_nested_items_to_be_public = false
 }
 

--- a/quickstart/202-machine-learning-moderately-secure-existing-VNet/workspace.tf
+++ b/quickstart/202-machine-learning-moderately-secure-existing-VNet/workspace.tf
@@ -21,11 +21,11 @@ resource "azurerm_key_vault" "default" {
 }
 
 resource "azurerm_storage_account" "default" {
-  name                     = "st${var.name}${var.environment}"
-  location                 = azurerm_resource_group.default.location
-  resource_group_name      = azurerm_resource_group.default.name
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
+  name                            = "st${var.name}${var.environment}"
+  location                        = azurerm_resource_group.default.location
+  resource_group_name             = azurerm_resource_group.default.name
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
   allow_nested_items_to_be_public = false
 
   network_rules {

--- a/quickstart/202-machine-learning-moderately-secure-existing-VNet/workspace.tf
+++ b/quickstart/202-machine-learning-moderately-secure-existing-VNet/workspace.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 
   network_rules {
     default_action = "Deny"

--- a/quickstart/301-machine-learning-hub-spoke-secure/workspace.tf
+++ b/quickstart/301-machine-learning-hub-spoke-secure/workspace.tf
@@ -22,11 +22,11 @@ resource "azurerm_key_vault" "default" {
 }
 
 resource "azurerm_storage_account" "default" {
-  name                     = "st${var.name}${var.environment}"
-  location                 = azurerm_resource_group.default.location
-  resource_group_name      = azurerm_resource_group.default.name
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
+  name                            = "st${var.name}${var.environment}"
+  location                        = azurerm_resource_group.default.location
+  resource_group_name             = azurerm_resource_group.default.name
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
   allow_nested_items_to_be_public = false
 
   network_rules {

--- a/quickstart/301-machine-learning-hub-spoke-secure/workspace.tf
+++ b/quickstart/301-machine-learning-hub-spoke-secure/workspace.tf
@@ -27,6 +27,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 
   network_rules {
     default_action = "Deny"


### PR DESCRIPTION
Explicitly disable storage blob public access for workspace templates as the default when creating an AML workspace.