### PR TITLE
101-cosmos-db-analyticalstore patch2

### DIFF
--- a/quickstart/101-cosmos-db-analyticalstore/variables.tf
+++ b/quickstart/101-cosmos-db-analyticalstore/variables.tf
@@ -50,6 +50,6 @@ variable "sql_container_name" {
 
 variable "analytical_storage_ttl" {
   type        = number
-  default     = 0
+  default     = -1
   description = "Analytical Storage TTL in seconds."
 }


### PR DESCRIPTION
- Change the default value of variable `analytical_storage_ttl` to -1