### PR TITLE
101-azure-virtual-desktop-anf - remove unused outputs

### DIFF
--- a/quickstart/101-azure-virtual-desktop-anf/outputs.tf
+++ b/quickstart/101-azure-virtual-desktop-anf/outputs.tf
@@ -23,16 +23,6 @@ output "location" {
   value       = azurerm_resource_group.rg.location
 }
 
-output "storage_account" {
-  description = "Storage account for Profiles"
-  value       = azurerm_storage_account.storage.name
-}
-
-output "storage_account_share" {
-  description = "Name of the Azure File Share created for FSLogix"
-  value       = azurerm_storage_share.FSShare.name
-}
-
 output "session_host_count" {
   description = "The number of VMs created"
   value       = var.rdsh_count


### PR DESCRIPTION
The error message indicates that it needs the existing vnet and aad user but they don't exist in Azure. So it's not related with this PR. I think we can fix the output error first.