### PR TITLE
Updated Ubuntu Image reference to the newly available images and fixed a deprecated parameter

### DIFF
--- a/quickstart/101-vm-cluster-linux/main.tf
+++ b/quickstart/101-vm-cluster-linux/main.tf
@@ -95,8 +95,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 

--- a/quickstart/201-machine-learning-moderately-secure/compute.tf
+++ b/quickstart/201-machine-learning-moderately-secure/compute.tf
@@ -3,7 +3,7 @@ resource "random_string" "ci_prefix" {
   length  = 8
   upper   = false
   special = false
-  number  = false
+  numeric  = false
 }
 
 # Compute instance

--- a/quickstart/201-vmss-jumpbox/main.tf
+++ b/quickstart/201-vmss-jumpbox/main.tf
@@ -27,7 +27,7 @@ resource "random_string" "fqdn" {
   length  = 6
   special = false
   upper   = false
-  number  = false
+  numeric  = false
 }
 
 resource "azurerm_virtual_network" "vmss" {

--- a/quickstart/201-vmss-jumpbox/main.tf
+++ b/quickstart/201-vmss-jumpbox/main.tf
@@ -105,8 +105,8 @@ resource "azurerm_virtual_machine_scale_set" "vmss" {
 
   storage_profile_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 
@@ -183,8 +183,8 @@ resource "azurerm_virtual_machine" "jumpbox" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 

--- a/quickstart/201-vmss-packer-jumpbox/main.tf
+++ b/quickstart/201-vmss-packer-jumpbox/main.tf
@@ -233,8 +233,8 @@ resource "azurerm_virtual_machine" "jumpbox" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 

--- a/quickstart/201-vmss-packer-jumpbox/ubuntu.pkr.hcl
+++ b/quickstart/201-vmss-packer-jumpbox/ubuntu.pkr.hcl
@@ -38,9 +38,9 @@ variable "image_resource_group_name" {
 source "azure-arm" "builder" {
   client_id                         = var.client_id
   client_secret                     = var.client_secret
-  image_offer                       = "UbuntuServer"
-  image_publisher                   = "canonical"
-  image_sku                         = "16.04-LTS"
+  image_offer                       = "ubuntu-24_04-lts"
+  image_publisher                   = "Canonical"
+  image_sku                         = "server-gen1"
   location                          = var.location
   managed_image_name                = "myPackerImage"
   managed_image_resource_group_name = var.image_resource_group_name

--- a/quickstart/301-hub-spoke/hub-nva.tf
+++ b/quickstart/301-hub-spoke/hub-nva.tf
@@ -40,8 +40,8 @@ resource "azurerm_virtual_machine" "hub-nva-vm" {
 
     storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
     }
 

--- a/quickstart/301-hub-spoke/hub-vnet.tf
+++ b/quickstart/301-hub-spoke/hub-vnet.tf
@@ -69,8 +69,8 @@ resource "azurerm_virtual_machine" "hub-vm" {
 
     storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
     }
 

--- a/quickstart/301-hub-spoke/on-prem.tf
+++ b/quickstart/301-hub-spoke/on-prem.tf
@@ -96,8 +96,8 @@ resource "azurerm_virtual_machine" "onprem-vm" {
 
     storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
     }
 

--- a/quickstart/301-hub-spoke/spoke1.tf
+++ b/quickstart/301-hub-spoke/spoke1.tf
@@ -69,8 +69,8 @@ resource "azurerm_virtual_machine" "spoke1-vm" {
 
     storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
     }
 

--- a/quickstart/301-hub-spoke/spoke2.tf
+++ b/quickstart/301-hub-spoke/spoke2.tf
@@ -73,8 +73,8 @@ resource "azurerm_virtual_machine" "spoke2-vm" {
 
     storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
     }
 

--- a/quickstart/301-machine-learning-hub-spoke-secure/azure-firewall.tf
+++ b/quickstart/301-machine-learning-hub-spoke-secure/azure-firewall.tf
@@ -3,7 +3,7 @@ resource "random_string" "fw_diag_prefix" {
   length  = 8
   upper   = false
   special = false
-  number  = false
+  numeric  = false
 }
 resource "azurerm_ip_group" "ip_group_hub" {
   name                = "hub-ipgroup"

--- a/quickstart/301-machine-learning-hub-spoke-secure/compute.tf
+++ b/quickstart/301-machine-learning-hub-spoke-secure/compute.tf
@@ -3,7 +3,7 @@ resource "random_string" "ci_prefix" {
   length  = 8
   upper   = false
   special = false
-  number  = false
+  numeric  = false
 }
 
 # Compute instance

--- a/samples/end-to-end-testing/src/main.tf
+++ b/samples/end-to-end-testing/src/main.tf
@@ -90,8 +90,8 @@ resource "azurerm_linux_virtual_machine" "vm1" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "18.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 }
@@ -133,8 +133,8 @@ resource "azurerm_linux_virtual_machine" "vm2" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "18.04-LTS"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
     version   = "latest"
   }
 }

--- a/solution_template/vm-linux-terraform/mainTemplate.json
+++ b/solution_template/vm-linux-terraform/mainTemplate.json
@@ -245,8 +245,8 @@
         "storageProfile": {
           "imageReference": {
             "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "16.04-LTS",
+            "offer": "ubuntu-24_04-lts",
+            "sku": "server-gen1",
             "version": "latest"
           },
           "osDisk": {


### PR DESCRIPTION
I have updated all ubuntu image references from old ones to the one that is currently available.
    publisher = "Canonical"
    offer     = "ubuntu-24_04-lts"
    sku       = "server-gen1"
    version   = "latest"
Also updated the parameter number in random_string to numeric as it is deprecated as per the documentation below.

https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string