### PR TITLE
`101-cosmos-db-azure-container-instance` - use `eastasia` region since `eastus` is lack of resource

### DIFF
--- a/quickstart/101-cosmos-db-azure-container-instance/providers.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance/providers.tf
@@ -14,5 +14,9 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }

--- a/quickstart/101-cosmos-db-azure-container-instance/variables.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance/variables.tf
@@ -1,5 +1,5 @@
 variable "resource_group_location" {
-  default     = "eastus"
+  default     = "East Asia"
   description = "Location of the resource group."
 }
 


### PR DESCRIPTION
This pr try to fix creation failure caused by lacking of resource in `eastus` region and destroy time failure, but still cannot work since the image `mcr.microsoft.com/azuredocs/azure-vote-front:cosmosdb` it used has been removed. We should merge it first, then try to figure out a new image instead.