### PR TITLE
Change output value from resource group ID to name

### DIFF
--- a/quickstart/101-azure-ai-foundry/outputs.tf
+++ b/quickstart/101-azure-ai-foundry/outputs.tf
@@ -1,5 +1,5 @@
 output "resource_group_name" {
-  value = azurerm_resource_group.example.id
+  value = azurerm_resource_group.example.name
 }
 
 output "workspace_name" {


### PR DESCRIPTION
This is used in https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/create-hub-terraform.  The CLI/PowerShell commands assume that the value is the NAME, not the ID.  Also the variable name is _name, not _id.  