### PR TITLE
Update Kubernetes versions of clusters to AKS supported.

### DIFF
--- a/quickstart/201-aks-clusters-fleet-manager-azapi/README.md
+++ b/quickstart/201-aks-clusters-fleet-manager-azapi/README.md
@@ -2,6 +2,8 @@
 
 This Terraform sample demonstrates how to use the AzAPI provider to manage Azure Kubernetes Fleet Manager resources, including Fleet, member clusters, update strategies, and auto-upgrade profiles.
 
+> Note: Kubernetes versions provided in the variables and examples files will periodically expire as they are no longer supported by AKS. If you find errors due to Kubernetes version returned in the TestRecord, update the contents to supported Kubernetes versions based on the [AKS documentation](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar).
+
 ## Terraform resource types
 
 - [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)

--- a/quickstart/201-aks-clusters-fleet-manager-azapi/terraform.tfvars.example
+++ b/quickstart/201-aks-clusters-fleet-manager-azapi/terraform.tfvars.example
@@ -8,9 +8,9 @@ member_cluster_names = []
 
 # Kubernetes Versions
 kubernetes_versions = {
-  member1 = "1.33"  # Staging
-  member2 = "1.32" # Production
-  member3 = "1.32" # Production
+  member1 = "1.36"  # Staging
+  member2 = "1.35" # Production
+  member3 = "1.35" # Production
 }
 
 # Node Configuration

--- a/quickstart/201-aks-clusters-fleet-manager-azapi/variables.tf
+++ b/quickstart/201-aks-clusters-fleet-manager-azapi/variables.tf
@@ -30,9 +30,9 @@ variable "kubernetes_versions" {
     member3 = string
   })
   default = {
-    member1 = "1.32"
-    member2 = "1.31"
-    member3 = "1.31"
+    member1 = "1.36"
+    member2 = "1.35"
+    member3 = "1.35"
   }
 }
 


### PR DESCRIPTION
This pull request updates the Kubernetes versions used in the Azure Kubernetes Fleet Manager Terraform sample to ensure compatibility with supported AKS versions. It also adds documentation to help users address issues related to expired Kubernetes versions.

Updates to Kubernetes versions:

* Updated default Kubernetes versions in the `kubernetes_versions` variable in `variables.tf` to use supported versions (`member1: 1.36`, `member2: 1.35`, `member3: 1.35`).
* Updated example Kubernetes versions in `terraform.tfvars.example` to match supported versions.

Documentation improvements:

* Added a note to `README.md` explaining that Kubernetes versions in the sample may expire and should be updated according to the [AKS documentation](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar).