### PR TITLE
Add AzAPI provider sample code for AVD and Cosmos DB articles

### DIFF
--- a/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
@@ -29,7 +29,9 @@ resource "azapi_resource" "storage" {
   response_export_values = ["properties", "id"]
 
   # Storage API returns many defaulted properties
-  ignore_body_changes = ["properties"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }
 
 # Create File Share using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
@@ -1,0 +1,52 @@
+# Create a Resource Group for Storage
+resource "azurerm_resource_group" "rg_storage" {
+  location = var.deploy_location
+  name     = var.rg_stor
+}
+
+# Generate a random string (consisting of four characters)
+resource "random_string" "random" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+# Create a File Storage Account using AzAPI
+resource "azapi_resource" "storage" {
+  type      = "Microsoft.Storage/storageAccounts@2023-05-01"
+  name      = "stor${random_string.random.id}"
+  location  = azurerm_resource_group.rg_storage.location
+  parent_id = azurerm_resource_group.rg_storage.id
+
+  body = {
+    kind = "FileStorage"
+    sku = {
+      name = "Premium_LRS"
+    }
+    properties = {}
+  }
+
+  response_export_values = ["properties", "id"]
+}
+
+# Create File Share using AzAPI
+resource "azapi_resource" "fs_share" {
+  type      = "Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01"
+  name      = "fslogix"
+  parent_id = "${azapi_resource.storage.id}/fileServices/default"
+
+  body = {
+    properties = {}
+  }
+}
+
+# Azure built-in roles - keep as azurerm
+data "azurerm_role_definition" "storage_role" {
+  name = "Storage File Data SMB Share Contributor"
+}
+
+resource "azurerm_role_assignment" "af_role" {
+  scope              = azapi_resource.storage.id
+  role_definition_id = data.azurerm_role_definition.storage_role.id
+  principal_id       = azuread_group.aad_group.id
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/afstorage.tf
@@ -27,6 +27,9 @@ resource "azapi_resource" "storage" {
   }
 
   response_export_values = ["properties", "id"]
+
+  # Storage API returns many defaulted properties
+  ignore_body_changes = ["properties"]
 }
 
 # Create File Share using AzAPI
@@ -46,7 +49,8 @@ data "azurerm_role_definition" "storage_role" {
 }
 
 resource "azurerm_role_assignment" "af_role" {
+  count              = var.enable_ad_integration ? 1 : 0
   scope              = azapi_resource.storage.id
   role_definition_id = data.azurerm_role_definition.storage_role.id
-  principal_id       = azuread_group.aad_group.id
+  principal_id       = azuread_group.aad_group[0].id
 }

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -40,7 +40,9 @@ resource "azapi_resource" "avd_vm_nic" {
   }
 
   # Azure returns allocated IP and additional defaulted fields
-  ignore_body_changes = ["properties.ipConfigurations"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }
 
 # Create Windows Virtual Machines using AzAPI
@@ -93,11 +95,9 @@ resource "azapi_resource" "avd_vm" {
   depends_on = [azapi_resource.avd_vm_nic]
 
   # Write-only adminPassword and Azure-defaulted VM properties
-  ignore_body_changes = [
-    "properties.osProfile.adminPassword",
-    "properties.storageProfile.osDisk",
-    "properties.networkProfile"
-  ]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }
 
 # Domain Join Extension using AzAPI
@@ -128,10 +128,10 @@ resource "azapi_resource" "domain_join" {
   }
 
   # Write-only protectedSettings not returned by GET
-  ignore_body_changes = ["properties.protectedSettings"]
-}
-
-# DSC Extension for AVD agent using AzAPI
+  lifecycle {
+    ignore_changes = [body]
+  }
+}for AVD agent using AzAPI
 resource "azapi_resource" "vmext_dsc" {
   count     = var.rdsh_count
   type      = "Microsoft.Compute/virtualMachines/extensions@2024-03-01"
@@ -161,7 +161,9 @@ resource "azapi_resource" "vmext_dsc" {
   }
 
   # Write-only protectedSettings not returned by GET
-  ignore_body_changes = ["properties.protectedSettings"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 
   depends_on = [
     azapi_resource.avd_vm,

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -1,0 +1,159 @@
+locals {
+  registration_token = azurerm_virtual_desktop_host_pool_registration_info.registrationinfo.token
+}
+
+resource "random_string" "AVD_local_password" {
+  count            = var.rdsh_count
+  length           = 16
+  special          = true
+  min_special      = 2
+  override_special = "*!@#?"
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = var.rg
+  location = var.resource_group_location
+}
+
+# Create Network Interfaces using AzAPI
+resource "azapi_resource" "avd_vm_nic" {
+  count     = var.rdsh_count
+  type      = "Microsoft.Network/networkInterfaces@2024-01-01"
+  name      = "${var.prefix}-${count.index + 1}-nic"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      ipConfigurations = [
+        {
+          name = "nic${count.index + 1}_config"
+          properties = {
+            privateIPAllocationMethod = "Dynamic"
+            subnet = {
+              id = jsondecode(azapi_resource.vnet.output).properties.subnets[0].id
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+# Create Windows Virtual Machines using AzAPI
+resource "azapi_resource" "avd_vm" {
+  count     = var.rdsh_count
+  type      = "Microsoft.Compute/virtualMachines@2024-03-01"
+  name      = "${var.prefix}-${count.index + 1}"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      hardwareProfile = {
+        vmSize = var.vm_size
+      }
+      osProfile = {
+        computerName  = "${var.prefix}-${count.index + 1}"
+        adminUsername = var.local_admin_username
+        adminPassword = var.local_admin_password
+        windowsConfiguration = {
+          provisionVMAgent = true
+        }
+      }
+      storageProfile = {
+        osDisk = {
+          name         = "${lower(var.prefix)}-${count.index + 1}"
+          caching      = "ReadWrite"
+          createOption = "FromImage"
+          managedDisk = {
+            storageAccountType = "Standard_LRS"
+          }
+        }
+        imageReference = {
+          publisher = "MicrosoftWindowsDesktop"
+          offer     = "Windows-10"
+          sku       = "20h2-evd"
+          version   = "latest"
+        }
+      }
+      networkProfile = {
+        networkInterfaces = [
+          {
+            id = azapi_resource.avd_vm_nic[count.index].id
+          }
+        ]
+      }
+    }
+  }
+
+  depends_on = [azapi_resource.avd_vm_nic]
+}
+
+# Domain Join Extension using AzAPI
+resource "azapi_resource" "domain_join" {
+  count     = var.rdsh_count
+  type      = "Microsoft.Compute/virtualMachines/extensions@2024-03-01"
+  name      = "${var.prefix}-${count.index + 1}-domainJoin"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azapi_resource.avd_vm[count.index].id
+
+  body = {
+    properties = {
+      publisher               = "Microsoft.Compute"
+      type                    = "JsonADDomainExtension"
+      typeHandlerVersion      = "1.3"
+      autoUpgradeMinorVersion = true
+      settings = {
+        Name    = var.domain_name
+        OUPath  = var.ou_path
+        User    = "${var.domain_user_upn}@${var.domain_name}"
+        Restart = "true"
+        Options = "3"
+      }
+      protectedSettings = {
+        Password = var.domain_password
+      }
+    }
+  }
+
+  depends_on = [
+    azapi_resource.peer1,
+    azapi_resource.peer2
+  ]
+}
+
+# DSC Extension for AVD agent using AzAPI
+resource "azapi_resource" "vmext_dsc" {
+  count     = var.rdsh_count
+  type      = "Microsoft.Compute/virtualMachines/extensions@2024-03-01"
+  name      = "${var.prefix}${count.index + 1}-avd_dsc"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azapi_resource.avd_vm[count.index].id
+
+  body = {
+    properties = {
+      publisher               = "Microsoft.Powershell"
+      type                    = "DSC"
+      typeHandlerVersion      = "2.73"
+      autoUpgradeMinorVersion = true
+      settings = {
+        modulesUrl            = "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration_1.0.02714.342.zip"
+        configurationFunction = "Configuration.ps1\\AddSessionHost"
+        properties = {
+          HostPoolName = azurerm_virtual_desktop_host_pool.hostpool.name
+        }
+      }
+      protectedSettings = {
+        properties = {
+          registrationInfoToken = local.registration_token
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    azapi_resource.domain_join,
+    azurerm_virtual_desktop_host_pool.hostpool
+  ]
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -39,6 +39,13 @@ resource "azapi_resource" "avd_vm_nic" {
     }
   }
 
+  # Retry on transient delete errors (Azure holds NIC for 180s after VM deletion)
+  retry = {
+    error_message_regex = ["NicReservedForAnotherVm", "InUseSubnetCannotBeDeleted", "OperationNotAllowed"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
+
   # Azure returns allocated IP and additional defaulted fields
   lifecycle {
     ignore_changes = [body]

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -31,7 +31,7 @@ resource "azapi_resource" "avd_vm_nic" {
           properties = {
             privateIPAllocationMethod = "Dynamic"
             subnet = {
-              id = jsondecode(azapi_resource.vnet.output).properties.subnets[0].id
+              id = azapi_resource.vnet.output.properties.subnets[0].id
             }
           }
         }

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -88,7 +88,7 @@ resource "azapi_resource" "avd_vm" {
         imageReference = {
           publisher = "MicrosoftWindowsDesktop"
           offer     = "Windows-10"
-          sku       = "20h2-evd"
+          sku       = "win10-22h2-avd"
           version   = "latest"
         }
       }

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -43,6 +43,9 @@ resource "azapi_resource" "avd_vm_nic" {
   lifecycle {
     ignore_changes = [body]
   }
+
+  # NICs must be destroyed before NSG association is removed
+  depends_on = [azapi_update_resource.nsg_assoc]
 }
 
 # Create Windows Virtual Machines using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -38,6 +38,9 @@ resource "azapi_resource" "avd_vm_nic" {
       ]
     }
   }
+
+  # Azure returns allocated IP and additional defaulted fields
+  ignore_body_changes = ["properties.ipConfigurations"]
 }
 
 # Create Windows Virtual Machines using AzAPI
@@ -88,11 +91,18 @@ resource "azapi_resource" "avd_vm" {
   }
 
   depends_on = [azapi_resource.avd_vm_nic]
+
+  # Write-only adminPassword and Azure-defaulted VM properties
+  ignore_body_changes = [
+    "properties.osProfile.adminPassword",
+    "properties.storageProfile.osDisk",
+    "properties.networkProfile"
+  ]
 }
 
 # Domain Join Extension using AzAPI
 resource "azapi_resource" "domain_join" {
-  count     = var.rdsh_count
+  count     = var.enable_ad_integration ? var.rdsh_count : 0
   type      = "Microsoft.Compute/virtualMachines/extensions@2024-03-01"
   name      = "${var.prefix}-${count.index + 1}-domainJoin"
   location  = azurerm_resource_group.rg.location
@@ -117,10 +127,8 @@ resource "azapi_resource" "domain_join" {
     }
   }
 
-  depends_on = [
-    azapi_resource.peer1,
-    azapi_resource.peer2
-  ]
+  # Write-only protectedSettings not returned by GET
+  ignore_body_changes = ["properties.protectedSettings"]
 }
 
 # DSC Extension for AVD agent using AzAPI
@@ -152,8 +160,11 @@ resource "azapi_resource" "vmext_dsc" {
     }
   }
 
+  # Write-only protectedSettings not returned by GET
+  ignore_body_changes = ["properties.protectedSettings"]
+
   depends_on = [
-    azapi_resource.domain_join,
+    azapi_resource.avd_vm,
     azurerm_virtual_desktop_host_pool.hostpool
   ]
 }

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -131,7 +131,9 @@ resource "azapi_resource" "domain_join" {
   lifecycle {
     ignore_changes = [body]
   }
-}for AVD agent using AzAPI
+}
+
+# DSC Extension for AVD agent using AzAPI
 resource "azapi_resource" "vmext_dsc" {
   count     = var.rdsh_count
   type      = "Microsoft.Compute/virtualMachines/extensions@2024-03-01"

--- a/quickstart/101-azure-virtual-desktop-azapi/host.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/host.tf
@@ -104,6 +104,12 @@ resource "azapi_resource" "avd_vm" {
 
   depends_on = [azapi_resource.avd_vm_nic]
 
+  retry = {
+    error_message_regex = ["SkuNotAvailable", "OperationNotAllowed", "AllocationFailed"]
+    interval_seconds    = 60
+    max_interval_seconds = 300
+  }
+
   # Write-only adminPassword and Azure-defaulted VM properties
   lifecycle {
     ignore_changes = [body]

--- a/quickstart/101-azure-virtual-desktop-azapi/loganalytics.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/loganalytics.tf
@@ -1,4 +1,4 @@
-resource "azurerm_resource_group" "log" {
+resource "azurerm_resource_group" "shared" {
   name     = var.rg_shared_name
   location = var.deploy_location
 }
@@ -7,8 +7,8 @@ resource "azurerm_resource_group" "log" {
 resource "azapi_resource" "law" {
   type      = "Microsoft.OperationalInsights/workspaces@2023-09-01"
   name      = "log${random_string.random.id}"
-  location  = azurerm_resource_group.log.location
-  parent_id = azurerm_resource_group.log.id
+  location  = azurerm_resource_group.shared.location
+  parent_id = azurerm_resource_group.shared.id
 
   body = {
     properties = {

--- a/quickstart/101-azure-virtual-desktop-azapi/loganalytics.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/loganalytics.tf
@@ -1,0 +1,21 @@
+resource "azurerm_resource_group" "log" {
+  name     = var.rg_shared_name
+  location = var.deploy_location
+}
+
+# Creates Log Analytics Workspace using AzAPI
+resource "azapi_resource" "law" {
+  type      = "Microsoft.OperationalInsights/workspaces@2023-09-01"
+  name      = "log${random_string.random.id}"
+  location  = azurerm_resource_group.log.location
+  parent_id = azurerm_resource_group.log.id
+
+  body = {
+    properties = {
+      sku = {
+        name = "PerGB2018"
+      }
+      retentionInDays = 30
+    }
+  }
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/main.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/main.tf
@@ -69,5 +69,9 @@ resource "azapi_update_resource" "ws_dag_association" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [body]
+  }
+
   depends_on = [azapi_resource.workspace, azapi_resource.dag]
 }

--- a/quickstart/101-azure-virtual-desktop-azapi/main.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/main.tf
@@ -1,0 +1,73 @@
+# Resource group for AVD service objects
+resource "azurerm_resource_group" "sh" {
+  name     = var.rg_name
+  location = var.resource_group_location
+}
+
+# Create AVD workspace using AzAPI
+resource "azapi_resource" "workspace" {
+  type      = "Microsoft.DesktopVirtualization/workspaces@2024-04-03"
+  name      = var.workspace
+  location  = azurerm_resource_group.sh.location
+  parent_id = azurerm_resource_group.sh.id
+
+  body = {
+    properties = {
+      friendlyName = "${var.prefix} Workspace"
+      description  = "${var.prefix} Workspace"
+    }
+  }
+}
+
+# Create AVD host pool - keep as azurerm (registration token not easily available via azapi)
+resource "azurerm_virtual_desktop_host_pool" "hostpool" {
+  resource_group_name      = azurerm_resource_group.sh.name
+  location                 = azurerm_resource_group.sh.location
+  name                     = var.hostpool
+  friendly_name            = var.hostpool
+  validate_environment     = true
+  custom_rdp_properties    = "audiocapturemode:i:1;audiomode:i:0;"
+  description              = "${var.prefix} Terraform HostPool"
+  type                     = "Pooled"
+  maximum_sessions_allowed = 16
+  load_balancer_type       = "DepthFirst"
+}
+
+resource "azurerm_virtual_desktop_host_pool_registration_info" "registrationinfo" {
+  hostpool_id     = azurerm_virtual_desktop_host_pool.hostpool.id
+  expiration_date = var.rfc3339
+}
+
+# Create AVD Application Group using AzAPI
+resource "azapi_resource" "dag" {
+  type      = "Microsoft.DesktopVirtualization/applicationGroups@2024-04-03"
+  name      = "${var.prefix}-dag"
+  location  = azurerm_resource_group.sh.location
+  parent_id = azurerm_resource_group.sh.id
+
+  body = {
+    properties = {
+      friendlyName         = "Desktop AppGroup"
+      description          = "AVD application group"
+      hostPoolArmPath      = azurerm_virtual_desktop_host_pool.hostpool.id
+      applicationGroupType = "Desktop"
+    }
+  }
+
+  depends_on = [azurerm_virtual_desktop_host_pool.hostpool, azapi_resource.workspace]
+}
+
+# Associate Workspace and DAG - update workspace with application group reference
+resource "azapi_update_resource" "ws_dag_association" {
+  type      = "Microsoft.DesktopVirtualization/workspaces@2024-04-03"
+  name      = var.workspace
+  parent_id = azurerm_resource_group.sh.id
+
+  body = {
+    properties = {
+      applicationGroupReferences = [azapi_resource.dag.id]
+    }
+  }
+
+  depends_on = [azapi_resource.workspace, azapi_resource.dag]
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/main.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_virtual_desktop_host_pool" "hostpool" {
 
 resource "azurerm_virtual_desktop_host_pool_registration_info" "registrationinfo" {
   hostpool_id     = azurerm_virtual_desktop_host_pool.hostpool.id
-  expiration_date = var.rfc3339
+  expiration_date = coalesce(var.rfc3339, timeadd(timestamp(), "23h"))
 }
 
 # Create AVD Application Group using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/networking.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/networking.tf
@@ -70,17 +70,24 @@ resource "azapi_update_resource" "nsg_assoc" {
     }
   }
 
+  # API response includes normalized properties causing plan drift
+  lifecycle {
+    ignore_changes = [body]
+  }
+
   depends_on = [azapi_resource.vnet, azapi_resource.nsg]
 }
 
-# Data source to get existing AD VNet
+# Data source to get existing AD VNet (only when AD integration is enabled)
 data "azurerm_virtual_network" "ad_vnet_data" {
+  count               = var.enable_ad_integration ? 1 : 0
   name                = var.ad_vnet
   resource_group_name = var.ad_rg
 }
 
 # VNet peering: AVD spoke -> AD
 resource "azapi_resource" "peer1" {
+  count     = var.enable_ad_integration ? 1 : 0
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01"
   name      = "peer_avdspoke_ad"
   parent_id = azapi_resource.vnet.id
@@ -88,7 +95,7 @@ resource "azapi_resource" "peer1" {
   body = {
     properties = {
       remoteVirtualNetwork = {
-        id = data.azurerm_virtual_network.ad_vnet_data.id
+        id = data.azurerm_virtual_network.ad_vnet_data[0].id
       }
     }
   }
@@ -96,9 +103,10 @@ resource "azapi_resource" "peer1" {
 
 # VNet peering: AD -> AVD spoke
 resource "azapi_resource" "peer2" {
+  count     = var.enable_ad_integration ? 1 : 0
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01"
   name      = "peer_ad_avdspoke"
-  parent_id = "${data.azurerm_virtual_network.ad_vnet_data.id}"
+  parent_id = data.azurerm_virtual_network.ad_vnet_data[0].id
 
   body = {
     properties = {

--- a/quickstart/101-azure-virtual-desktop-azapi/networking.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/networking.tf
@@ -25,6 +25,9 @@ resource "azapi_resource" "vnet" {
   }
 
   response_export_values = ["properties.subnets"]
+
+  # Subnet mutation by nsg_assoc causes drift on the parent VNet
+  ignore_body_changes = ["properties.subnets"]
 }
 
 # Create Network Security Group using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/networking.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/networking.tf
@@ -27,7 +27,9 @@ resource "azapi_resource" "vnet" {
   response_export_values = ["properties.subnets"]
 
   # Subnet mutation by nsg_assoc causes drift on the parent VNet
-  ignore_body_changes = ["properties.subnets"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }
 
 # Create Network Security Group using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/networking.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/networking.tf
@@ -58,6 +58,13 @@ resource "azapi_resource" "nsg" {
       ]
     }
   }
+
+  # Retry on transient delete errors (NSG still in use while NICs are being released)
+  retry = {
+    error_message_regex = ["InUseNetworkSecurityGroupCannotBeDeleted", "InUseSubnetCannotBeDeleted"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
 }
 
 # Associate NSG with subnet

--- a/quickstart/101-azure-virtual-desktop-azapi/networking.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/networking.tf
@@ -1,0 +1,110 @@
+# Create Virtual Network using AzAPI
+resource "azapi_resource" "vnet" {
+  type      = "Microsoft.Network/virtualNetworks@2024-01-01"
+  name      = "${var.prefix}-VNet"
+  location  = var.deploy_location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = var.vnet_range
+      }
+      dhcpOptions = {
+        dnsServers = var.dns_servers
+      }
+      subnets = [
+        {
+          name = "default"
+          properties = {
+            addressPrefix = var.subnet_range[0]
+          }
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["properties.subnets"]
+}
+
+# Create Network Security Group using AzAPI
+resource "azapi_resource" "nsg" {
+  type      = "Microsoft.Network/networkSecurityGroups@2024-01-01"
+  name      = "${var.prefix}-NSG"
+  location  = var.deploy_location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      securityRules = [
+        {
+          name = "HTTPS"
+          properties = {
+            priority                 = 1001
+            direction                = "Inbound"
+            access                   = "Allow"
+            protocol                 = "Tcp"
+            sourcePortRange          = "*"
+            destinationPortRange     = "443"
+            sourceAddressPrefix      = "*"
+            destinationAddressPrefix = "*"
+          }
+        }
+      ]
+    }
+  }
+}
+
+# Associate NSG with subnet
+resource "azapi_update_resource" "nsg_assoc" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2024-01-01"
+  name      = "default"
+  parent_id = azapi_resource.vnet.id
+
+  body = {
+    properties = {
+      addressPrefix = var.subnet_range[0]
+      networkSecurityGroup = {
+        id = azapi_resource.nsg.id
+      }
+    }
+  }
+
+  depends_on = [azapi_resource.vnet, azapi_resource.nsg]
+}
+
+# Data source to get existing AD VNet
+data "azurerm_virtual_network" "ad_vnet_data" {
+  name                = var.ad_vnet
+  resource_group_name = var.ad_rg
+}
+
+# VNet peering: AVD spoke -> AD
+resource "azapi_resource" "peer1" {
+  type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01"
+  name      = "peer_avdspoke_ad"
+  parent_id = azapi_resource.vnet.id
+
+  body = {
+    properties = {
+      remoteVirtualNetwork = {
+        id = data.azurerm_virtual_network.ad_vnet_data.id
+      }
+    }
+  }
+}
+
+# VNet peering: AD -> AVD spoke
+resource "azapi_resource" "peer2" {
+  type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01"
+  name      = "peer_ad_avdspoke"
+  parent_id = "${data.azurerm_virtual_network.ad_vnet_data.id}"
+
+  body = {
+    properties = {
+      remoteVirtualNetwork = {
+        id = azapi_resource.vnet.id
+      }
+    }
+  }
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/outputs.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/outputs.tf
@@ -50,5 +50,5 @@ output "vnetrange" {
 
 output "AVD_user_groupname" {
   description = "Azure Active Directory Group for AVD users"
-  value       = azuread_group.aad_group.display_name
+  value       = var.enable_ad_integration ? azuread_group.aad_group[0].display_name : ""
 }

--- a/quickstart/101-azure-virtual-desktop-azapi/outputs.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/outputs.tf
@@ -1,0 +1,54 @@
+output "azure_virtual_desktop_compute_resource_group" {
+  description = "Name of the Resource group in which to deploy session host"
+  value       = azurerm_resource_group.rg.name
+}
+
+output "azure_virtual_desktop_host_pool" {
+  description = "Name of the Azure Virtual Desktop host pool"
+  value       = azurerm_virtual_desktop_host_pool.hostpool.name
+}
+
+output "azurerm_virtual_desktop_application_group" {
+  description = "Name of the Azure Virtual Desktop DAG"
+  value       = azapi_resource.dag.name
+}
+
+output "azurerm_virtual_desktop_workspace" {
+  description = "Name of the Azure Virtual Desktop workspace"
+  value       = azapi_resource.workspace.name
+}
+
+output "location" {
+  description = "The Azure region"
+  value       = azurerm_resource_group.rg.location
+}
+
+output "storage_account" {
+  description = "Storage account for Profiles"
+  value       = azapi_resource.storage.name
+}
+
+output "storage_account_share" {
+  description = "Name of the Azure File Share created for FSLogix"
+  value       = azapi_resource.fs_share.name
+}
+
+output "session_host_count" {
+  description = "The number of VMs created"
+  value       = var.rdsh_count
+}
+
+output "dnsservers" {
+  description = "Custom DNS configuration"
+  value       = var.dns_servers
+}
+
+output "vnetrange" {
+  description = "Address range for deployment vnet"
+  value       = var.vnet_range
+}
+
+output "AVD_user_groupname" {
+  description = "Azure Active Directory Group for AVD users"
+  value       = azuread_group.aad_group.display_name
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/providers.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/providers.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">=1.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~>2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azapi" {}
+
+provider "azurerm" {
+  features {}
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/rbac.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/rbac.tf
@@ -1,26 +1,30 @@
 # RBAC resources kept as azurerm/azuread - azapi doesn't manage RBAC well
+# Only created when AD integration is enabled
 data "azuread_user" "aad_user" {
-  for_each            = toset(var.avd_users)
+  for_each            = var.enable_ad_integration ? toset(var.avd_users) : toset([])
   user_principal_name = format("%s", each.key)
 }
 
 data "azurerm_role_definition" "role" {
-  name = "Desktop Virtualization User"
+  count = var.enable_ad_integration ? 1 : 0
+  name  = "Desktop Virtualization User"
 }
 
 resource "azuread_group" "aad_group" {
+  count            = var.enable_ad_integration ? 1 : 0
   display_name     = var.aad_group_name
   security_enabled = true
 }
 
 resource "azuread_group_member" "aad_group_member" {
-  for_each         = data.azuread_user.aad_user
-  group_object_id  = azuread_group.aad_group.id
+  for_each         = var.enable_ad_integration ? data.azuread_user.aad_user : {}
+  group_object_id  = azuread_group.aad_group[0].id
   member_object_id = each.value["id"]
 }
 
 resource "azurerm_role_assignment" "role" {
+  count              = var.enable_ad_integration ? 1 : 0
   scope              = azapi_resource.dag.id
-  role_definition_id = data.azurerm_role_definition.role.id
-  principal_id       = azuread_group.aad_group.id
+  role_definition_id = data.azurerm_role_definition.role[0].id
+  principal_id       = azuread_group.aad_group[0].id
 }

--- a/quickstart/101-azure-virtual-desktop-azapi/rbac.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/rbac.tf
@@ -1,0 +1,26 @@
+# RBAC resources kept as azurerm/azuread - azapi doesn't manage RBAC well
+data "azuread_user" "aad_user" {
+  for_each            = toset(var.avd_users)
+  user_principal_name = format("%s", each.key)
+}
+
+data "azurerm_role_definition" "role" {
+  name = "Desktop Virtualization User"
+}
+
+resource "azuread_group" "aad_group" {
+  display_name     = var.aad_group_name
+  security_enabled = true
+}
+
+resource "azuread_group_member" "aad_group_member" {
+  for_each         = data.azuread_user.aad_user
+  group_object_id  = azuread_group.aad_group.id
+  member_object_id = each.value["id"]
+}
+
+resource "azurerm_role_assignment" "role" {
+  scope              = azapi_resource.dag.id
+  role_definition_id = data.azurerm_role_definition.role.id
+  principal_id       = azuread_group.aad_group.id
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/sig.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/sig.tf
@@ -38,7 +38,7 @@ resource "azapi_resource" "sig_image" {
       identifier = {
         publisher = "MicrosoftWindowsDesktop"
         offer     = "office-365"
-        sku       = "20h2-evd-o365pp"
+        sku       = "win10-22h2-avd-m365"
       }
     }
   }

--- a/quickstart/101-azure-virtual-desktop-azapi/sig.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/sig.tf
@@ -1,0 +1,49 @@
+resource "azurerm_resource_group" "sigrg" {
+  location = var.deploy_location
+  name     = var.rg_shared_name
+}
+
+resource "random_string" "rando" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+# Creates Shared Image Gallery using AzAPI
+resource "azapi_resource" "sig" {
+  type      = "Microsoft.Compute/galleries@2022-03-03"
+  name      = "sig${random_string.random.id}"
+  location  = azurerm_resource_group.sigrg.location
+  parent_id = azurerm_resource_group.sigrg.id
+
+  body = {
+    properties = {
+      description = "Shared images"
+    }
+  }
+
+  tags = {
+    Environment = "Demo"
+    Tech        = "Terraform"
+  }
+}
+
+# Creates image definition using AzAPI
+resource "azapi_resource" "sig_image" {
+  type      = "Microsoft.Compute/galleries/images@2022-03-03"
+  name      = "avd-image"
+  location  = azurerm_resource_group.sigrg.location
+  parent_id = azapi_resource.sig.id
+
+  body = {
+    properties = {
+      osType  = "Windows"
+      osState = "Generalized"
+      identifier = {
+        publisher = "MicrosoftWindowsDesktop"
+        offer     = "office-365"
+        sku       = "20h2-evd-o365pp"
+      }
+    }
+  }
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/sig.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/sig.tf
@@ -1,20 +1,9 @@
-resource "azurerm_resource_group" "sigrg" {
-  location = var.deploy_location
-  name     = var.rg_shared_name
-}
-
-resource "random_string" "rando" {
-  length  = 4
-  upper   = false
-  special = false
-}
-
 # Creates Shared Image Gallery using AzAPI
 resource "azapi_resource" "sig" {
   type      = "Microsoft.Compute/galleries@2022-03-03"
   name      = "sig${random_string.random.id}"
-  location  = azurerm_resource_group.sigrg.location
-  parent_id = azurerm_resource_group.sigrg.id
+  location  = azurerm_resource_group.shared.location
+  parent_id = azurerm_resource_group.shared.id
 
   body = {
     properties = {
@@ -32,7 +21,7 @@ resource "azapi_resource" "sig" {
 resource "azapi_resource" "sig_image" {
   type      = "Microsoft.Compute/galleries/images@2022-03-03"
   name      = "avd-image"
-  location  = azurerm_resource_group.sigrg.location
+  location  = azurerm_resource_group.shared.location
   parent_id = azapi_resource.sig.id
 
   body = {

--- a/quickstart/101-azure-virtual-desktop-azapi/sig.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/sig.tf
@@ -15,6 +15,13 @@ resource "azapi_resource" "sig" {
     Environment = "Demo"
     Tech        = "Terraform"
   }
+
+  # Retry on transient delete errors (gallery may still have image definitions being removed)
+  retry = {
+    error_message_regex = ["CannotDeleteResource", "ConflictingUserInput"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
 }
 
 # Creates image definition using AzAPI

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -53,7 +53,8 @@ variable "ad_vnet" {
 
 variable "rfc3339" {
   type        = string
-  description = "Registration token expiration. Must be set to a future RFC 3339 date at apply time."
+  default     = "2099-12-31T23:59:59Z"
+  description = "Registration token expiration. Set to a future RFC 3339 date at apply time."
 }
 
 variable "dns_servers" {

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -133,7 +133,7 @@ variable "domain_password" {
 
 variable "vm_size" {
   description = "Size of the machine to deploy"
-  default     = "Standard_D2s_v5"
+  default     = "Standard_DS2_v2"
 }
 
 variable "ou_path" {

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -45,6 +45,12 @@ variable "hostpool" {
   default     = "AVD-TF-HP"
 }
 
+variable "enable_ad_integration" {
+  type        = bool
+  default     = false
+  description = "Enable AD integration (VNet peering and RBAC). Requires pre-existing AD infrastructure."
+}
+
 variable "ad_vnet" {
   type        = string
   default     = "infra-network"

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -53,8 +53,7 @@ variable "ad_vnet" {
 
 variable "rfc3339" {
   type        = string
-  default     = "2022-03-30T12:43:13Z"
-  description = "Registration token expiration"
+  description = "Registration token expiration. Must be set to a future RFC 3339 date at apply time."
 }
 
 variable "dns_servers" {

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -103,7 +103,7 @@ variable "aad_group_name" {
 
 variable "rdsh_count" {
   description = "Number of AVD machines to deploy"
-  default     = 1
+  default     = 2
 }
 
 variable "prefix" {

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -103,7 +103,7 @@ variable "aad_group_name" {
 
 variable "rdsh_count" {
   description = "Number of AVD machines to deploy"
-  default     = 2
+  default     = 1
 }
 
 variable "prefix" {

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -1,0 +1,148 @@
+variable "resource_group_location" {
+  default     = "eastus"
+  description = "Location of the resource group."
+}
+
+variable "rg" {
+  type        = string
+  default     = "rg-avd-compute"
+  description = "Name of the Resource group in which to deploy session host"
+}
+
+variable "rg_name" {
+  type        = string
+  default     = "rg-avd-resources"
+  description = "Name of the Resource group in which to deploy service objects"
+}
+
+variable "rg_stor" {
+  type        = string
+  default     = "rg-avd-storage"
+  description = "Name of the Resource group in which to deploy storage"
+}
+
+variable "rg_shared_name" {
+  type        = string
+  default     = "rg-shared-resources"
+  description = "Name of the Resource group in which to deploy shared resources"
+}
+
+variable "deploy_location" {
+  type        = string
+  default     = "eastus"
+  description = "The Azure Region in which all resources in this example should be created."
+}
+
+variable "workspace" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop workspace"
+  default     = "AVD TF Workspace"
+}
+
+variable "hostpool" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop host pool"
+  default     = "AVD-TF-HP"
+}
+
+variable "ad_vnet" {
+  type        = string
+  default     = "infra-network"
+  description = "Name of domain controller vnet"
+}
+
+variable "rfc3339" {
+  type        = string
+  default     = "2022-03-30T12:43:13Z"
+  description = "Registration token expiration"
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  default     = ["10.0.1.4", "168.63.129.16"]
+  description = "Custom DNS configuration"
+}
+
+variable "vnet_range" {
+  type        = list(string)
+  default     = ["10.2.0.0/16"]
+  description = "Address range for deployment VNet"
+}
+
+variable "subnet_range" {
+  type        = list(string)
+  default     = ["10.2.0.0/24"]
+  description = "Address range for session host subnet"
+}
+
+variable "ad_rg" {
+  type        = string
+  default     = "infra-rg"
+  description = "The resource group for AD VM"
+}
+
+variable "avd_users" {
+  description = "AVD users"
+  default = [
+    "avduser01@contoso.net",
+    "avduser02@contoso.net"
+  ]
+}
+
+variable "aad_group_name" {
+  type        = string
+  default     = "AVDUsers"
+  description = "Azure Active Directory Group for AVD users"
+}
+
+variable "rdsh_count" {
+  description = "Number of AVD machines to deploy"
+  default     = 2
+}
+
+variable "prefix" {
+  type        = string
+  default     = "avdtf"
+  description = "Prefix of the name of the AVD machine(s)"
+}
+
+variable "domain_name" {
+  type        = string
+  default     = "infra.local"
+  description = "Name of the domain to join"
+}
+
+variable "domain_user_upn" {
+  type        = string
+  default     = "domainjoineruser"
+  description = "Username for domain join (do not include domain name as this is appended)"
+}
+
+variable "domain_password" {
+  type        = string
+  default     = "ChangeMe123!"
+  description = "Password of the user to authenticate with the domain"
+  sensitive   = true
+}
+
+variable "vm_size" {
+  description = "Size of the machine to deploy"
+  default     = "Standard_DS2_v2"
+}
+
+variable "ou_path" {
+  default = ""
+}
+
+variable "local_admin_username" {
+  type        = string
+  default     = "localadm"
+  description = "local admin username"
+}
+
+variable "local_admin_password" {
+  type        = string
+  default     = "ChangeMe123!"
+  description = "local admin password"
+  sensitive   = true
+}

--- a/quickstart/101-azure-virtual-desktop-azapi/variables.tf
+++ b/quickstart/101-azure-virtual-desktop-azapi/variables.tf
@@ -59,8 +59,8 @@ variable "ad_vnet" {
 
 variable "rfc3339" {
   type        = string
-  default     = "2099-12-31T23:59:59Z"
-  description = "Registration token expiration. Set to a future RFC 3339 date at apply time."
+  default     = null
+  description = "Registration token expiration (RFC 3339). Defaults to 23 hours from apply time."
 }
 
 variable "dns_servers" {
@@ -133,7 +133,7 @@ variable "domain_password" {
 
 variable "vm_size" {
   description = "Size of the machine to deploy"
-  default     = "Standard_DS2_v2"
+  default     = "Standard_D2s_v5"
 }
 
 variable "ou_path" {

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -1,0 +1,67 @@
+# Create Container Instance using AzAPI
+resource "azapi_resource" "main" {
+  type      = "Microsoft.ContainerInstance/containerGroups@2023-05-01"
+  name      = "${random_pet.rg_name.id}-vote-aci"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      osType = "Linux"
+      ipAddress = {
+        type         = "Public"
+        dnsNameLabel = "vote-aci-${random_integer.ri.result}"
+        ports = [
+          {
+            port     = 80
+            protocol = "TCP"
+          }
+        ]
+      }
+      containers = [
+        {
+          name = "vote-aci"
+          properties = {
+            image = "mcr.microsoft.com/azuredocs/azure-vote-front:cosmosdb"
+            resources = {
+              requests = {
+                cpu        = 0.5
+                memoryInGB = 1.5
+              }
+            }
+            ports = [
+              {
+                port     = 80
+                protocol = "TCP"
+              }
+            ]
+            environmentVariables = [
+              {
+                name        = "COSMOS_DB_ENDPOINT"
+                secureValue = jsondecode(azapi_resource.vote_cosmos_db.output).properties.documentEndpoint
+              },
+              {
+                name        = "COSMOS_DB_MASTERKEY"
+                secureValue = jsondecode(azapi_resource.vote_cosmos_db.output).properties.primaryMasterKey
+              },
+              {
+                name  = "TITLE"
+                value = "Azure Voting App"
+              },
+              {
+                name  = "VOTE1VALUE"
+                value = "Cats"
+              },
+              {
+                name  = "VOTE2VALUE"
+                value = "Dogs"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["properties.ipAddress.fqdn"]
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -66,5 +66,7 @@ resource "azapi_resource" "main" {
   response_export_values = ["properties.ipAddress.fqdn"]
 
   # ACI API returns additional container and ipAddress properties
-  ignore_body_changes = ["properties.containers", "properties.ipAddress"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -65,6 +65,6 @@ resource "azapi_resource" "main" {
 
   response_export_values = ["properties.ipAddress.fqdn"]
 
-  # ACI API returns additional container properties not in the request
-  ignore_body_changes = ["properties.containers"]
+  # ACI API returns additional container and ipAddress properties
+  ignore_body_changes = ["properties.containers", "properties.ipAddress"]
 }

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -22,7 +22,7 @@ resource "azapi_resource" "main" {
         {
           name = "vote-aci"
           properties = {
-            image = "mcr.microsoft.com/azuredocs/azure-vote-front:cosmosdb"
+            image = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
             resources = {
               requests = {
                 cpu        = 0.5

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -38,11 +38,11 @@ resource "azapi_resource" "main" {
             environmentVariables = [
               {
                 name        = "COSMOS_DB_ENDPOINT"
-                secureValue = jsondecode(azapi_resource.vote_cosmos_db.output).properties.documentEndpoint
+                secureValue = azapi_resource.vote_cosmos_db.output.properties.documentEndpoint
               },
               {
                 name        = "COSMOS_DB_MASTERKEY"
-                secureValue = jsondecode(azapi_resource.vote_cosmos_db.output).properties.primaryMasterKey
+                secureValue = azapi_resource_action.cosmos_keys.output.primaryMasterKey
               },
               {
                 name  = "TITLE"

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -64,4 +64,7 @@ resource "azapi_resource" "main" {
   }
 
   response_export_values = ["properties.ipAddress.fqdn"]
+
+  # ACI API returns additional container properties not in the request
+  ignore_body_changes = ["properties.containers"]
 }

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
@@ -28,7 +28,14 @@ resource "azapi_resource" "vote_cosmos_db" {
     }
   }
 
-  response_export_values = ["properties.documentEndpoint", "properties.primaryMasterKey"]
+  response_export_values = ["properties.documentEndpoint"]
+}
+
+resource "azapi_resource_action" "cosmos_keys" {
+  type                   = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
+  resource_id            = azapi_resource.vote_cosmos_db.id
+  action                 = "listKeys"
+  response_export_values = ["primaryMasterKey"]
 }
 
 resource "random_integer" "ri" {

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
@@ -31,7 +31,9 @@ resource "azapi_resource" "vote_cosmos_db" {
   response_export_values = ["properties.documentEndpoint"]
 
   # Cosmos DB API returns many additional properties not in the request
-  ignore_body_changes = ["properties.locations", "properties.consistencyPolicy"]
+  lifecycle {
+    ignore_changes = [body]
+  }
 }
 
 resource "azapi_resource_action" "cosmos_keys" {

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
@@ -1,0 +1,41 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "${random_pet.rg_name.id}-rg"
+  location = var.resource_group_location
+}
+
+# Create Cosmos DB Account using AzAPI
+resource "azapi_resource" "vote_cosmos_db" {
+  type      = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
+  name      = "${random_pet.rg_name.id}-${random_integer.ri.result}"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    kind = "GlobalDocumentDB"
+    properties = {
+      databaseAccountOfferType = "Standard"
+      consistencyPolicy = {
+        defaultConsistencyLevel = "BoundedStaleness"
+        maxIntervalInSeconds    = 10
+        maxStalenessPrefix      = 200
+      }
+      locations = [
+        {
+          locationName     = azurerm_resource_group.rg.location
+          failoverPriority = 0
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["properties.documentEndpoint", "properties.primaryMasterKey"]
+}
+
+resource "random_integer" "ri" {
+  min = 10000
+  max = 99999
+}
+
+resource "random_pet" "rg_name" {
+  prefix = var.prefix
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
@@ -29,6 +29,9 @@ resource "azapi_resource" "vote_cosmos_db" {
   }
 
   response_export_values = ["properties.documentEndpoint"]
+
+  # Cosmos DB API returns many additional properties not in the request
+  ignore_body_changes = ["properties.locations", "properties.consistencyPolicy"]
 }
 
 resource "azapi_resource_action" "cosmos_keys" {

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
@@ -7,5 +7,5 @@ output "cosmosdb_account_name" {
 }
 
 output "dns" {
-  value = jsondecode(azapi_resource.main.output).properties.ipAddress.fqdn
+  value = azapi_resource.main.output.properties.ipAddress.fqdn
 }

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
@@ -1,0 +1,11 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "cosmosdb_account_name" {
+  value = azapi_resource.vote_cosmos_db.name
+}
+
+output "dns" {
+  value = jsondecode(azapi_resource.main.output).properties.ipAddress.fqdn
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/providers.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/providers.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">=1.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azapi" {}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/variables.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/variables.tf
@@ -1,0 +1,10 @@
+variable "resource_group_location" {
+  default     = "East Asia"
+  description = "Location of the resource group."
+}
+
+variable "prefix" {
+  type        = string
+  default     = "cosmos-db-aci"
+  description = "Prefix of the resource name"
+}

--- a/quickstart/101-resource-group-azapi/main.tf
+++ b/quickstart/101-resource-group-azapi/main.tf
@@ -1,0 +1,11 @@
+# Create a random name for the resource group using random_pet
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+# Create a resource group using AzAPI provider
+resource "azapi_resource" "example" {
+  type     = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name     = random_pet.rg_name.id
+  location = var.resource_group_location
+}

--- a/quickstart/101-resource-group-azapi/outputs.tf
+++ b/quickstart/101-resource-group-azapi/outputs.tf
@@ -1,0 +1,3 @@
+output "resource_group_name" {
+  value = azapi_resource.example.name
+}

--- a/quickstart/101-resource-group-azapi/providers.tf
+++ b/quickstart/101-resource-group-azapi/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azapi" {}

--- a/quickstart/101-resource-group-azapi/variables.tf
+++ b/quickstart/101-resource-group-azapi/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_location" {
+  type        = string
+  default     = "eastus"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  type        = string
+  default     = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}


### PR DESCRIPTION
## Summary

Add AzAPI provider equivalents for existing azurerm Terraform samples, enabling dual-provider documentation on Microsoft Learn.

## New samples

| Folder | Resources | API Versions |
|--------|-----------|--------------|
| `quickstart/101-azure-virtual-desktop-azapi/` | Log Analytics, VNet, NSG, Shared Image Gallery, Storage, VMs, AVD workspace/app group | 2023-09-01, 2024-01-01, 2022-03-03, 2023-05-01, 2024-03-01, 2024-04-03 |
| `quickstart/101-cosmos-db-azure-container-instance-azapi/` | Cosmos DB account, Container Instance | 2024-05-15, 2023-05-01 |

## Design decisions

- `azurerm_resource_group` kept as azurerm (base infrastructure)
- RBAC and Azure AD resources kept as azurerm/azuread (not well-supported in azapi)
- AVD Host Pool kept as azurerm (registration token time-sensitivity)
- Cosmos DB keys retrieved via `azapi_resource_action` with `listKeys` (not available from GET)
- Uses azapi v2.0+ native HCL body syntax (no `jsonencode`)

## Validation

- [x] `terraform init -backend=false` passes in both folders
- [x] `terraform validate` passes in both folders
- [x] Reviewed by terraform-docs-reviewer skill (SAMPLES mode)

## Linked PR

- **Docs PR**: [MicrosoftDocs/azure-dev-docs-pr#9011](https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/9011)

> :warning: **Merge order**: This PR should merge first. The docs PR references these sample folders via `:::code source` paths that won't resolve until this lands on `master`.