### PR TITLE
Add AzAPI samples: Cosmos DB + ACI and resource-group

### DIFF
--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/aci.tf
@@ -1,0 +1,72 @@
+# Create Container Instance using AzAPI
+resource "azapi_resource" "main" {
+  type      = "Microsoft.ContainerInstance/containerGroups@2023-05-01"
+  name      = "${random_pet.rg_name.id}-vote-aci"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    properties = {
+      osType = "Linux"
+      ipAddress = {
+        type         = "Public"
+        dnsNameLabel = "vote-aci-${random_integer.ri.result}"
+        ports = [
+          {
+            port     = 80
+            protocol = "TCP"
+          }
+        ]
+      }
+      containers = [
+        {
+          name = "vote-aci"
+          properties = {
+            image = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+            resources = {
+              requests = {
+                cpu        = 0.5
+                memoryInGB = 1.5
+              }
+            }
+            ports = [
+              {
+                port     = 80
+                protocol = "TCP"
+              }
+            ]
+            environmentVariables = [
+              {
+                name        = "COSMOS_DB_ENDPOINT"
+                secureValue = azapi_resource.vote_cosmos_db.output.properties.documentEndpoint
+              },
+              {
+                name        = "COSMOS_DB_MASTERKEY"
+                secureValue = azapi_resource_action.cosmos_keys.output.primaryMasterKey
+              },
+              {
+                name  = "TITLE"
+                value = "Azure Voting App"
+              },
+              {
+                name  = "VOTE1VALUE"
+                value = "Cats"
+              },
+              {
+                name  = "VOTE2VALUE"
+                value = "Dogs"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["properties.ipAddress.fqdn"]
+
+  # ACI API returns additional container and ipAddress properties
+  lifecycle {
+    ignore_changes = [body]
+  }
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/main.tf
@@ -1,0 +1,53 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "${random_pet.rg_name.id}-rg"
+  location = var.resource_group_location
+}
+
+# Create Cosmos DB Account using AzAPI
+resource "azapi_resource" "vote_cosmos_db" {
+  type      = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
+  name      = "${random_pet.rg_name.id}-${random_integer.ri.result}"
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+
+  body = {
+    kind = "GlobalDocumentDB"
+    properties = {
+      databaseAccountOfferType = "Standard"
+      consistencyPolicy = {
+        defaultConsistencyLevel = "BoundedStaleness"
+        maxIntervalInSeconds    = 10
+        maxStalenessPrefix      = 200
+      }
+      locations = [
+        {
+          locationName     = azurerm_resource_group.rg.location
+          failoverPriority = 0
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["properties.documentEndpoint"]
+
+  # Cosmos DB API returns many additional properties not in the request
+  lifecycle {
+    ignore_changes = [body]
+  }
+}
+
+resource "azapi_resource_action" "cosmos_keys" {
+  type                   = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
+  resource_id            = azapi_resource.vote_cosmos_db.id
+  action                 = "listKeys"
+  response_export_values = ["primaryMasterKey"]
+}
+
+resource "random_integer" "ri" {
+  min = 10000
+  max = 99999
+}
+
+resource "random_pet" "rg_name" {
+  prefix = var.prefix
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/outputs.tf
@@ -1,0 +1,11 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "cosmosdb_account_name" {
+  value = azapi_resource.vote_cosmos_db.name
+}
+
+output "dns" {
+  value = azapi_resource.main.output.properties.ipAddress.fqdn
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/providers.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/providers.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">=1.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azapi" {}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/quickstart/101-cosmos-db-azure-container-instance-azapi/variables.tf
+++ b/quickstart/101-cosmos-db-azure-container-instance-azapi/variables.tf
@@ -1,0 +1,10 @@
+variable "resource_group_location" {
+  default     = "East Asia"
+  description = "Location of the resource group."
+}
+
+variable "prefix" {
+  type        = string
+  default     = "cosmos-db-aci"
+  description = "Prefix of the resource name"
+}

--- a/quickstart/101-resource-group-azapi/main.tf
+++ b/quickstart/101-resource-group-azapi/main.tf
@@ -1,0 +1,11 @@
+# Create a random name for the resource group using random_pet
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+# Create a resource group using AzAPI provider
+resource "azapi_resource" "example" {
+  type     = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name     = random_pet.rg_name.id
+  location = var.resource_group_location
+}

--- a/quickstart/101-resource-group-azapi/outputs.tf
+++ b/quickstart/101-resource-group-azapi/outputs.tf
@@ -1,0 +1,3 @@
+output "resource_group_name" {
+  value = azapi_resource.example.name
+}

--- a/quickstart/101-resource-group-azapi/providers.tf
+++ b/quickstart/101-resource-group-azapi/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azapi" {}

--- a/quickstart/101-resource-group-azapi/variables.tf
+++ b/quickstart/101-resource-group-azapi/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_location" {
+  type        = string
+  default     = "eastus"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  type        = string
+  default     = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}


### PR DESCRIPTION
## Summary
Add two new AzAPI provider sample directories that complement existing azurerm versions:

- **101-cosmos-db-azure-container-instance-azapi**: Cosmos DB account with Azure Container Instance
- **101-resource-group-azapi**: Simple resource group

These samples support upcoming AzAPI tab additions to MS Learn Terraform documentation.

> **Note:** The AVD AzAPI sample (101-azure-virtual-desktop-azapi) is being stabilized separately in PR #483 due to transient Azure capacity issues in CI. This PR contains only the samples that consistently pass e2e tests.

## Related PRs
- Azure/terraform#484 — Rename folders to suffix convention
- MicrosoftDocs/azure-dev-docs-pr#9011 — Add AzAPI tabs to articles
- MicrosoftDocs/azure-dev-docs-pr#9012 — Update paths for renamed folders