### PR TITLE
Add AKS Automatic cluster quickstart sample

### DIFF
--- a/quickstart/101-aks-automatic-azapi/main.tf
+++ b/quickstart/101-aks-automatic-azapi/main.tf
@@ -1,0 +1,38 @@
+# Create a random name for the resource group using random_pet
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+# Create a resource group using the generated random name
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name     = random_pet.rg_name.id
+}
+
+# Create a random name for the AKS Automatic cluster
+resource "random_pet" "cluster_name" {
+  prefix = var.cluster_name_prefix
+}
+
+# Create the AKS Automatic cluster.
+# The AzAPI provider is used because the AzureRM provider's azurerm_kubernetes_cluster
+# resource always sets the managed cluster SKU name to "Base" and can't create the
+# "Automatic" SKU.
+resource "azapi_resource" "aks_automatic" {
+  type      = "Microsoft.ContainerService/managedClusters@2026-02-01"
+  name      = random_pet.cluster_name.id
+  parent_id = azurerm_resource_group.rg.id
+  location  = azurerm_resource_group.rg.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  body = {
+    sku = {
+      name = var.cluster_sku_name
+    }
+  }
+
+  response_export_values = ["properties.nodeResourceGroup", "properties.fqdn"]
+}

--- a/quickstart/101-aks-automatic-azapi/main.tf
+++ b/quickstart/101-aks-automatic-azapi/main.tf
@@ -15,9 +15,10 @@ resource "random_pet" "cluster_name" {
 }
 
 # Create the AKS Automatic cluster.
-# The AzAPI provider is used because the AzureRM provider's azurerm_kubernetes_cluster
-# resource always sets the managed cluster SKU name to "Base" and can't create the
-# "Automatic" SKU.
+# The AzAPI provider is used here to get direct control over the managed cluster
+# API payload and API version. Reach for this pattern when you need a property
+# or an API version that the AzureRM provider hasn't surfaced yet. For the
+# provider-native equivalent, see the 101-aks-automatic sample.
 resource "azapi_resource" "aks_automatic" {
   type      = "Microsoft.ContainerService/managedClusters@2026-02-01"
   name      = random_pet.cluster_name.id
@@ -30,7 +31,7 @@ resource "azapi_resource" "aks_automatic" {
 
   body = {
     sku = {
-      name = var.cluster_sku_name
+      name = "Automatic"
     }
   }
 

--- a/quickstart/101-aks-automatic-azapi/outputs.tf
+++ b/quickstart/101-aks-automatic-azapi/outputs.tf
@@ -1,0 +1,15 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "cluster_name" {
+  value = azapi_resource.aks_automatic.name
+}
+
+output "cluster_id" {
+  value = azapi_resource.aks_automatic.id
+}
+
+output "node_resource_group" {
+  value = azapi_resource.aks_automatic.output.properties.nodeResourceGroup
+}

--- a/quickstart/101-aks-automatic-azapi/providers.tf
+++ b/quickstart/101-aks-automatic-azapi/providers.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.0"
+      version = "~>5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/quickstart/101-aks-automatic-azapi/providers.tf
+++ b/quickstart/101-aks-automatic-azapi/providers.tf
@@ -1,9 +1,13 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>5.0"
+      version = "~>4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -14,4 +18,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azapi" {
 }

--- a/quickstart/101-aks-automatic-azapi/readme.md
+++ b/quickstart/101-aks-automatic-azapi/readme.md
@@ -1,0 +1,30 @@
+# Azure Kubernetes Service (AKS) Automatic cluster (AzAPI provider)
+
+This template deploys an AKS Automatic cluster with a system-assigned managed identity into a resource group with a random name beginning with "rg-".
+
+The cluster is declared with the AzAPI provider's [`azapi_resource`](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) against the `Microsoft.ContainerService/managedClusters` API. Use this pattern when you need direct control over the managed cluster API payload, or when you need an API version or property that the AzureRM provider doesn't expose yet.
+
+For the equivalent sample that uses the AzureRM provider's `azurerm_kubernetes_automatic_cluster` resource, see [101-aks-automatic](../101-aks-automatic/).
+
+## Terraform resource types
+
+- [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)
+
+## Variables
+
+| Name | Description | Default | Validation |
+|-|-|-|-|
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg | |
+| `resource_group_location` | Location of the resource group. | eastus | |
+| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic | |
+| `cluster_sku_name` | The managed cluster SKU name. Use `Automatic` for an AKS Automatic cluster. | Automatic | Must be `Automatic` or `Base`. |
+
+## Example
+
+```console
+terraform init -upgrade
+terraform plan -out main.tfplan
+terraform apply main.tfplan
+```

--- a/quickstart/101-aks-automatic-azapi/readme.md
+++ b/quickstart/101-aks-automatic-azapi/readme.md
@@ -20,9 +20,6 @@ For the equivalent sample that uses the AzureRM provider's `azurerm_kubernetes_a
 | `resource_group_location` | Location of the resource group. | westus2 |
 | `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic |
 
-> [!NOTE]
-> The default location is `westus2` because that's the region this sample was validated in. At the time of testing, `eastus` returned `AKSCapacityHeavyUsage` for API Server VNet Integration. Set `resource_group_location` to deploy elsewhere.
-
 ## Example
 
 ```console
@@ -30,3 +27,4 @@ terraform init -upgrade
 terraform plan -out main.tfplan
 terraform apply main.tfplan
 ```
+

--- a/quickstart/101-aks-automatic-azapi/readme.md
+++ b/quickstart/101-aks-automatic-azapi/readme.md
@@ -2,7 +2,7 @@
 
 This template deploys an AKS Automatic cluster with a system-assigned managed identity into a resource group with a random name beginning with "rg-".
 
-The cluster is declared with the AzAPI provider's [`azapi_resource`](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) against the `Microsoft.ContainerService/managedClusters` API. Use this pattern when you need direct control over the managed cluster API payload, or when you need an API version or property that the AzureRM provider doesn't expose yet.
+The cluster is declared with the AzAPI provider's [`azapi_resource`](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) against the `Microsoft.ContainerService/managedClusters` API. Use this pattern when you need direct control over the managed cluster API payload, or when you need an API version or property that the AzureRM provider doesn't expose yet. The cluster SKU is hard-coded to `Automatic`.
 
 For the equivalent sample that uses the AzureRM provider's `azurerm_kubernetes_automatic_cluster` resource, see [101-aks-automatic](../101-aks-automatic/).
 
@@ -14,12 +14,14 @@ For the equivalent sample that uses the AzureRM provider's `azurerm_kubernetes_a
 
 ## Variables
 
-| Name | Description | Default | Validation |
-|-|-|-|-|
-| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg | |
-| `resource_group_location` | Location of the resource group. | eastus | |
-| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic | |
-| `cluster_sku_name` | The managed cluster SKU name. Use `Automatic` for an AKS Automatic cluster. | Automatic | Must be `Automatic` or `Base`. |
+| Name | Description | Default |
+|-|-|-|
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg |
+| `resource_group_location` | Location of the resource group. | westus2 |
+| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic |
+
+> [!NOTE]
+> The default location is `westus2` because that's the region this sample was validated in. At the time of testing, `eastus` returned `AKSCapacityHeavyUsage` for API Server VNet Integration. Set `resource_group_location` to deploy elsewhere.
 
 ## Example
 

--- a/quickstart/101-aks-automatic-azapi/variables.tf
+++ b/quickstart/101-aks-automatic-azapi/variables.tf
@@ -15,3 +15,14 @@ variable "cluster_name_prefix" {
   default     = "aks-automatic"
   description = "Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription."
 }
+
+variable "cluster_sku_name" {
+  type        = string
+  default     = "Automatic"
+  description = "The managed cluster SKU name. Use 'Automatic' for an AKS Automatic cluster."
+
+  validation {
+    condition     = contains(["Automatic", "Base"], var.cluster_sku_name)
+    error_message = "The cluster_sku_name value must be either 'Automatic' or 'Base'."
+  }
+}

--- a/quickstart/101-aks-automatic-azapi/variables.tf
+++ b/quickstart/101-aks-automatic-azapi/variables.tf
@@ -1,6 +1,6 @@
 variable "resource_group_location" {
   type        = string
-  default     = "eastus"
+  default     = "westus2"
   description = "Location of the resource group."
 }
 
@@ -14,15 +14,4 @@ variable "cluster_name_prefix" {
   type        = string
   default     = "aks-automatic"
   description = "Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription."
-}
-
-variable "cluster_sku_name" {
-  type        = string
-  default     = "Automatic"
-  description = "The managed cluster SKU name. Use 'Automatic' for an AKS Automatic cluster."
-
-  validation {
-    condition     = contains(["Automatic", "Base"], var.cluster_sku_name)
-    error_message = "The cluster_sku_name value must be either 'Automatic' or 'Base'."
-  }
 }

--- a/quickstart/101-aks-automatic/main.tf
+++ b/quickstart/101-aks-automatic/main.tf
@@ -1,0 +1,38 @@
+# Create a random name for the resource group using random_pet
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+# Create a resource group using the generated random name
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name     = random_pet.rg_name.id
+}
+
+# Create a random name for the AKS Automatic cluster
+resource "random_pet" "cluster_name" {
+  prefix = var.cluster_name_prefix
+}
+
+# Create the AKS Automatic cluster.
+# The AzAPI provider is used because the AzureRM provider's azurerm_kubernetes_cluster
+# resource always sets the managed cluster SKU name to "Base" and can't create the
+# "Automatic" SKU.
+resource "azapi_resource" "aks_automatic" {
+  type      = "Microsoft.ContainerService/managedClusters@2026-02-01"
+  name      = random_pet.cluster_name.id
+  parent_id = azurerm_resource_group.rg.id
+  location  = azurerm_resource_group.rg.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  body = {
+    sku = {
+      name = var.cluster_sku_name
+    }
+  }
+
+  response_export_values = ["properties.nodeResourceGroup", "properties.fqdn"]
+}

--- a/quickstart/101-aks-automatic/main.tf
+++ b/quickstart/101-aks-automatic/main.tf
@@ -14,25 +14,13 @@ resource "random_pet" "cluster_name" {
   prefix = var.cluster_name_prefix
 }
 
-# Create the AKS Automatic cluster.
-# The AzAPI provider is used because the AzureRM provider's azurerm_kubernetes_cluster
-# resource always sets the managed cluster SKU name to "Base" and can't create the
-# "Automatic" SKU.
-resource "azapi_resource" "aks_automatic" {
-  type      = "Microsoft.ContainerService/managedClusters@2026-02-01"
-  name      = random_pet.cluster_name.id
-  parent_id = azurerm_resource_group.rg.id
-  location  = azurerm_resource_group.rg.location
+# Create the AKS Automatic cluster
+resource "azurerm_kubernetes_automatic_cluster" "aks_automatic" {
+  name                = random_pet.cluster_name.id
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   identity {
     type = "SystemAssigned"
   }
-
-  body = {
-    sku = {
-      name = var.cluster_sku_name
-    }
-  }
-
-  response_export_values = ["properties.nodeResourceGroup", "properties.fqdn"]
 }

--- a/quickstart/101-aks-automatic/outputs.tf
+++ b/quickstart/101-aks-automatic/outputs.tf
@@ -3,13 +3,17 @@ output "resource_group_name" {
 }
 
 output "cluster_name" {
-  value = azapi_resource.aks_automatic.name
+  value = azurerm_kubernetes_automatic_cluster.aks_automatic.name
 }
 
 output "cluster_id" {
-  value = azapi_resource.aks_automatic.id
+  value = azurerm_kubernetes_automatic_cluster.aks_automatic.id
 }
 
-output "node_resource_group" {
-  value = azapi_resource.aks_automatic.output.properties.nodeResourceGroup
+output "node_resource_group_id" {
+  value = azurerm_kubernetes_automatic_cluster.aks_automatic.node_resource_group_id
+}
+
+output "fully_qualified_domain_name" {
+  value = azurerm_kubernetes_automatic_cluster.aks_automatic.fully_qualified_domain_name
 }

--- a/quickstart/101-aks-automatic/outputs.tf
+++ b/quickstart/101-aks-automatic/outputs.tf
@@ -1,0 +1,15 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "cluster_name" {
+  value = azapi_resource.aks_automatic.name
+}
+
+output "cluster_id" {
+  value = azapi_resource.aks_automatic.id
+}
+
+output "node_resource_group" {
+  value = azapi_resource.aks_automatic.output.properties.nodeResourceGroup
+}

--- a/quickstart/101-aks-automatic/providers.tf
+++ b/quickstart/101-aks-automatic/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~>2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {
+}

--- a/quickstart/101-aks-automatic/readme.md
+++ b/quickstart/101-aks-automatic/readme.md
@@ -1,23 +1,24 @@
-# Azure Kubernetes Service (AKS) Automatic cluster
+# Azure Kubernetes Service (AKS) Automatic cluster (AzureRM provider)
 
 This template deploys an AKS Automatic cluster with a system-assigned managed identity into a resource group with a random name beginning with "rg-".
 
-AKS Automatic is created with the `Automatic` managed cluster SKU. The AzAPI provider is used for the cluster because the AzureRM provider's `azurerm_kubernetes_cluster` resource only supports the `Base` SKU.
+The cluster is created with the AzureRM provider's [`azurerm_kubernetes_automatic_cluster`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_automatic_cluster) resource, which is the recommended way to declare an AKS Automatic cluster. This resource requires AzureRM provider `5.0` or later.
+
+For an equivalent sample that declares the same cluster with the AzAPI provider, see [101-aks-automatic-azapi](../101-aks-automatic-azapi/).
 
 ## Terraform resource types
 
 - [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)
 - [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
-- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)
+- [azurerm_kubernetes_automatic_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_automatic_cluster)
 
 ## Variables
 
-| Name | Description | Default | Validation |
-|-|-|-|-|
-| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg | |
-| `resource_group_location` | Location of the resource group. | eastus | |
-| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic | |
-| `cluster_sku_name` | The managed cluster SKU name. Use `Automatic` for an AKS Automatic cluster. | Automatic | Must be `Automatic` or `Base`. |
+| Name | Description | Default |
+|-|-|-|
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg |
+| `resource_group_location` | Location of the resource group. | eastus |
+| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic |
 
 ## Example
 

--- a/quickstart/101-aks-automatic/readme.md
+++ b/quickstart/101-aks-automatic/readme.md
@@ -2,7 +2,7 @@
 
 This template deploys an AKS Automatic cluster with a system-assigned managed identity into a resource group with a random name beginning with "rg-".
 
-The cluster is created with the AzureRM provider's [`azurerm_kubernetes_automatic_cluster`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_automatic_cluster) resource, which is the recommended way to declare an AKS Automatic cluster. This resource requires AzureRM provider `5.0` or later.
+The cluster is created with the AzureRM provider's [`azurerm_kubernetes_automatic_cluster`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_automatic_cluster) resource, which is the recommended way to declare an AKS Automatic cluster. This resource requires AzureRM provider `v4.81` or later.
 
 For an equivalent sample that declares the same cluster with the AzAPI provider, see [101-aks-automatic-azapi](../101-aks-automatic-azapi/).
 
@@ -20,9 +20,6 @@ For an equivalent sample that declares the same cluster with the AzAPI provider,
 | `resource_group_location` | Location of the resource group. | westus2 |
 | `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic |
 
-> [!NOTE]
-> The default location is `westus2` because that's the region this sample was validated in. At the time of testing, `eastus` returned `AKSCapacityHeavyUsage` for API Server VNet Integration. Set `resource_group_location` to deploy elsewhere.
-
 ## Example
 
 ```console
@@ -30,3 +27,4 @@ terraform init -upgrade
 terraform plan -out main.tfplan
 terraform apply main.tfplan
 ```
+

--- a/quickstart/101-aks-automatic/readme.md
+++ b/quickstart/101-aks-automatic/readme.md
@@ -17,8 +17,11 @@ For an equivalent sample that declares the same cluster with the AzAPI provider,
 | Name | Description | Default |
 |-|-|-|
 | `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg |
-| `resource_group_location` | Location of the resource group. | eastus |
+| `resource_group_location` | Location of the resource group. | westus2 |
 | `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic |
+
+> [!NOTE]
+> The default location is `westus2` because that's the region this sample was validated in. At the time of testing, `eastus` returned `AKSCapacityHeavyUsage` for API Server VNet Integration. Set `resource_group_location` to deploy elsewhere.
 
 ## Example
 

--- a/quickstart/101-aks-automatic/readme.md
+++ b/quickstart/101-aks-automatic/readme.md
@@ -1,0 +1,28 @@
+# Azure Kubernetes Service (AKS) Automatic cluster
+
+This template deploys an AKS Automatic cluster with a system-assigned managed identity into a resource group with a random name beginning with "rg-".
+
+AKS Automatic is created with the `Automatic` managed cluster SKU. The AzAPI provider is used for the cluster because the AzureRM provider's `azurerm_kubernetes_cluster` resource only supports the `Base` SKU.
+
+## Terraform resource types
+
+- [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)
+
+## Variables
+
+| Name | Description | Default | Validation |
+|-|-|-|-|
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg | |
+| `resource_group_location` | Location of the resource group. | eastus | |
+| `cluster_name_prefix` | Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription. | aks-automatic | |
+| `cluster_sku_name` | The managed cluster SKU name. Use `Automatic` for an AKS Automatic cluster. | Automatic | Must be `Automatic` or `Base`. |
+
+## Example
+
+```console
+terraform init -upgrade
+terraform plan -out main.tfplan
+terraform apply main.tfplan
+```

--- a/quickstart/101-aks-automatic/variables.tf
+++ b/quickstart/101-aks-automatic/variables.tf
@@ -1,6 +1,6 @@
 variable "resource_group_location" {
   type        = string
-  default     = "eastus"
+  default     = "westus2"
   description = "Location of the resource group."
 }
 

--- a/quickstart/101-aks-automatic/variables.tf
+++ b/quickstart/101-aks-automatic/variables.tf
@@ -1,0 +1,28 @@
+variable "resource_group_location" {
+  type        = string
+  default     = "eastus"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  type        = string
+  default     = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+
+variable "cluster_name_prefix" {
+  type        = string
+  default     = "aks-automatic"
+  description = "Prefix of the AKS Automatic cluster name that's combined with a random ID so the name is unique in your Azure subscription."
+}
+
+variable "cluster_sku_name" {
+  type        = string
+  default     = "Automatic"
+  description = "The managed cluster SKU name. Use 'Automatic' for an AKS Automatic cluster."
+
+  validation {
+    condition     = contains(["Automatic", "Base"], var.cluster_sku_name)
+    error_message = "The cluster_sku_name value must be either 'Automatic' or 'Base'."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Terraform quickstart sample that deploys an Azure Kubernetes Service (AKS) Automatic cluster with a system-assigned managed identity.

## Why AzAPI

The AzureRM provider's `azurerm_kubernetes_cluster` resource always sets the managed cluster SKU name to `Base` and can't create the `Automatic` SKU, so the cluster is declared with `azapi_resource`. This follows existing AzAPI precedent in the repo (`201-aks-clusters-fleet-manager-azapi`, `101-azapi-eventhub-network-rules`).

## Contents

`quickstart/101-aks-automatic/`

- `providers.tf`
- `main.tf`
- `variables.tf`
- `outputs.tf`
- `readme.md`

## Testing

This sample was deployed and torn down against a live Azure subscription before submission.

| Step | Result |
|-|-|
| `terraform fmt` | no changes |
| `terraform validate` | success |
| `terraform apply` | success — 4 resources added, 16m42s |
| Verification | `sku.name = Automatic`, `sku.tier = Standard`, `provisioningState = Succeeded`, `identity = SystemAssigned`, Kubernetes 1.35.6 |
| `terraform destroy` | success — 4 resources destroyed |
| Teardown check | resource group confirmed deleted |

Region: `eastus`.

`TestRecord.md` is intentionally omitted — the CI pipeline generates it.
