### PR TITLE
Add AKS Key Vault access quickstart

### DIFF
--- a/quickstart/101-aks-access-keyvault/README.md
+++ b/quickstart/101-aks-access-keyvault/README.md
@@ -1,0 +1,120 @@
+# Access Azure Key Vault from Azure Kubernetes Service (AKS)
+
+This template configures an AKS cluster to access an Azure Key Vault secret using the Secrets Store CSI Driver.
+
+## Prerequisites
+
+- An Azure account with an active subscription
+- Terraform installed
+- Azure CLI installed and signed in with `az login`
+- `kubectl` installed
+- Permissions to create Azure resources and role assignments
+
+Set the active subscription:
+
+```bash
+az account set --subscription <subscription-id>
+```
+
+## Terraform resource types
+
+- [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azurerm_log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace)
+- [azurerm_kubernetes_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster)
+- [azurerm_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault)
+- [azurerm_key_vault_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret)
+- [azurerm_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)
+
+## Example
+
+Initialize, format, and validate the configuration:
+
+```bash
+terraform init
+terraform fmt
+terraform validate
+```
+
+Review and apply the configuration:
+
+```bash
+terraform plan
+terraform apply
+```
+
+Configure `kubectl` access to the cluster:
+
+```bash
+az aks get-credentials \
+  --resource-group rg-aks-kv-csi-demo \
+  --name aks-kv-csi-demo
+```
+
+The Terraform outputs include the Key Vault name, secret name, tenant ID, and AKS CSI identity IDs.
+
+## Create a SecretProviderClass
+
+Save the following manifest as `secret_provider_class.yaml`. Replace the placeholder values with the Terraform outputs:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: azure-keyvault-secrets
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "true"
+    userAssignedIdentityID: "<AKS_CSI_CLIENT_ID>"
+    keyvaultName: "<KEY_VAULT_NAME>"
+    tenantId: "<TENANT_ID>"
+    objects: |
+      array:
+        - |
+          objectName: ExampleSecret
+          objectType: secret
+```
+
+## Create a test pod
+
+Save the following manifest as `pod.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sc-demo-keyvault-csi
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: ["/bin/sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "azure-keyvault-secrets"
+```
+
+Apply the manifests:
+
+```bash
+kubectl apply -f secret_provider_class.yaml
+kubectl apply -f pod.yaml
+```
+
+Verify that the secret is mounted in the pod:
+
+```bash
+kubectl get pod/sc-demo-keyvault-csi
+kubectl exec sc-demo-keyvault-csi -- ls /mnt/secrets-store/
+kubectl exec sc-demo-keyvault-csi -- cat /mnt/secrets-store/ExampleSecret
+```

--- a/quickstart/101-aks-access-keyvault/main.tf
+++ b/quickstart/101-aks-access-keyvault/main.tf
@@ -14,7 +14,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/quickstart/101-aks-access-keyvault/main.tf
+++ b/quickstart/101-aks-access-keyvault/main.tf
@@ -31,7 +31,7 @@ resource "random_string" "suffix" {
 
 locals {
   location            = "eastus"
-  resource_group_name = "rg-aks-kv-csi-demo"
+  resource_group_name = "rg-aks-kv-csi-demo-${random_string.suffix.result}"
   aks_name            = "aks-kv-csi-demo"
   key_vault_name      = "kvcsidemo${random_string.suffix.result}"
   secret_name         = "ExampleSecret"

--- a/quickstart/101-aks-access-keyvault/main.tf
+++ b/quickstart/101-aks-access-keyvault/main.tf
@@ -63,6 +63,12 @@ resource "azurerm_kubernetes_cluster" "this" {
     name       = "system"
     node_count = 1
     vm_size    = "Standard_D2s_v3"
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
   }
 
   identity {

--- a/quickstart/101-aks-access-keyvault/main.tf
+++ b/quickstart/101-aks-access-keyvault/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   default_node_pool {
     name       = "system"
     node_count = 1
-    vm_size    = "Standard_B4ms"
+    vm_size    = "Standard_D2s_v3"
   }
 
   identity {

--- a/quickstart/101-aks-access-keyvault/main.tf
+++ b/quickstart/101-aks-access-keyvault/main.tf
@@ -1,0 +1,147 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "random_string" "suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
+locals {
+  location            = "eastus"
+  resource_group_name = "rg-aks-kv-csi-demo"
+  aks_name            = "aks-kv-csi-demo"
+  key_vault_name      = "kvcsidemo${random_string.suffix.result}"
+  secret_name         = "ExampleSecret"
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = local.resource_group_name
+  location = local.location
+}
+
+resource "azurerm_log_analytics_workspace" "this" {
+  name                = "law-aks-kv-csi-demo"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_kubernetes_cluster" "this" {
+  name                      = local.aks_name
+  location                  = azurerm_resource_group.this.location
+  resource_group_name       = azurerm_resource_group.this.name
+  dns_prefix                = "akskvcsidemo"
+  kubernetes_version        = null
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name       = "system"
+    node_count = 1
+    vm_size    = "Standard_B4ms"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  key_vault_secrets_provider {
+    secret_rotation_enabled = false
+  }
+
+  oms_agent {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+  }
+
+  network_profile {
+    network_plugin    = "azure"
+    load_balancer_sku = "standard"
+  }
+
+  tags = {
+    scenario = "aks-keyvault-csi"
+  }
+}
+
+resource "azurerm_key_vault" "this" {
+  name                          = local.key_vault_name
+  location                      = azurerm_resource_group.this.location
+  resource_group_name           = azurerm_resource_group.this.name
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  sku_name                      = "standard"
+  purge_protection_enabled      = false
+  soft_delete_retention_days    = 7
+  enable_rbac_authorization     = true
+  public_network_access_enabled = true
+}
+
+resource "azurerm_role_assignment" "current_user_kv_admin" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_secret" "example" {
+  name         = local.secret_name
+  value        = "HelloFromKeyVault"
+  key_vault_id = azurerm_key_vault.this.id
+
+  depends_on = [
+    azurerm_role_assignment.current_user_kv_admin
+  ]
+}
+
+resource "azurerm_role_assignment" "aks_csi_secrets_user" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Secrets User"
+  # This is the managed identity automatically created by the AKS Key Vault CSI addon.
+  principal_id = azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].object_id
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.this.name
+}
+
+output "aks_cluster_name" {
+  value = azurerm_kubernetes_cluster.this.name
+}
+
+output "key_vault_name" {
+  value = azurerm_key_vault.this.name
+}
+
+output "key_vault_secret_name" {
+  value = azurerm_key_vault_secret.example.name
+}
+
+output "tenant_id" {
+  value = data.azurerm_client_config.current.tenant_id
+}
+
+output "aks_csi_client_id" {
+  value = azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].client_id
+}
+
+output "aks_csi_object_id" {
+  value = azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].object_id
+}


### PR DESCRIPTION
Adds a Terraform quickstart sample for configuring AKS access to Azure Key Vault using the Secrets Store CSI Driver.

This sample includes:
Terraform configuration for the AKS cluster, Azure Key Vault, required role assignments, and Key Vault secret.
Kubernetes manifests for the SecretProviderClass and test pod.
README instructions for deploying and validating the sample.

Validation:

terraform fmt -check passed
terraform validate passed