### PR TITLE
Add network-isolated AKS quickstart

### DIFF
--- a/quickstart/101-aks-network-isolated/README.md
+++ b/quickstart/101-aks-network-isolated/README.md
@@ -44,7 +44,7 @@ terraform plan
 terraform apply
 ```
 
-The configuration creates a system-assigned private AKS cluster with Azure networking, `outboundType` set to `none`, and bootstrap artifact caching enabled with `artifactSource` set to `Cache`.
+The configuration creates a system-assigned private AKS cluster with Azure networking, `outboundType` set to `none`, and bootstrap artifact caching enabled with `artifactSource` set to `Cache`. The cluster is created with the default supported Kubernetes version for the selected region. To pin a specific version, add `kubernetesVersion` to the cluster `properties` block and confirm the version is available in the region with `az aks get-versions --location <region>`.
 
 ## Verify the deployment
 

--- a/quickstart/101-aks-network-isolated/README.md
+++ b/quickstart/101-aks-network-isolated/README.md
@@ -1,0 +1,71 @@
+# Create a Network Isolated AKS Cluster
+
+This template deploys a private, network-isolated Azure Kubernetes Service (AKS) cluster using the AKS-managed Azure Container Registry (ACR) cache.
+
+A network-isolated cluster reduces outbound internet dependencies by retrieving required deployment artifacts from a cached ACR source instead of directly from Microsoft Artifact Registry (MAR). AKS manages the bootstrap artifact cache for this scenario, so the template does not create or manage an ACR resource.
+
+The AzureRM provider does not currently expose all of the network-isolated AKS bootstrap settings used by this sample. The AzAPI provider is used to deploy the resource with the required managed-cluster API version.
+
+## Prerequisites
+
+- An Azure subscription
+- Terraform `>= 1.6.0` installed
+- Azure CLI installed and authenticated with `az login`
+- `kubectl` installed
+- Permission to create Azure resource groups and AKS clusters
+- A supported Azure region for network-isolated AKS
+
+Verify the Azure CLI session:
+
+```console
+az login
+az account show
+```
+
+## Terraform resource types
+
+- [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/azapi_resource)
+
+## Example
+
+Initialize, format, and validate the configuration:
+
+```console
+terraform init
+terraform fmt
+terraform validate
+```
+
+Review and apply the configuration:
+
+```console
+terraform plan
+terraform apply
+```
+
+The configuration creates a system-assigned private AKS cluster with Azure networking, `outboundType` set to `none`, and bootstrap artifact caching enabled with `artifactSource` set to `Cache`.
+
+## Verify the deployment
+
+Retrieve the AKS cluster credentials using the resource group and cluster names shown in the deployment output:
+
+```console
+az aks get-credentials \
+  --resource-group <resource-group-name> \
+  --name <cluster-name>
+```
+
+Verify the cluster nodes:
+
+```console
+kubectl get nodes
+```
+
+## Clean up resources
+
+Remove the deployed resources when they are no longer needed:
+
+```console
+terraform destroy
+```

--- a/quickstart/101-aks-network-isolated/main.tf
+++ b/quickstart/101-aks-network-isolated/main.tf
@@ -46,8 +46,7 @@ resource "azapi_resource" "aks_cluster" {
 
   body = {
     properties = {
-      dnsPrefix         = local.dns_prefix
-      kubernetesVersion = "1.30.3"
+      dnsPrefix = local.dns_prefix
       agentPoolProfiles = [
         {
           name              = "systempool"

--- a/quickstart/101-aks-network-isolated/main.tf
+++ b/quickstart/101-aks-network-isolated/main.tf
@@ -22,7 +22,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  location            = "eastus"
+  location            = "westus2"
   resource_group_name = "rg-aks-network-isolated-${random_string.suffix.result}"
   aks_name            = "aks-netisolated-${random_string.suffix.result}"
   dns_prefix          = "aksnetiso${random_string.suffix.result}"

--- a/quickstart/101-aks-network-isolated/main.tf
+++ b/quickstart/101-aks-network-isolated/main.tf
@@ -51,7 +51,7 @@ resource "azapi_resource" "aks_cluster" {
         {
           name              = "systempool"
           count             = 1
-          vmSize            = "Standard_DS2_v2"
+          vmSize            = "Standard_DS2_v3"
           mode              = "System"
           osType            = "Linux"
           type              = "VirtualMachineScaleSets"

--- a/quickstart/101-aks-network-isolated/main.tf
+++ b/quickstart/101-aks-network-isolated/main.tf
@@ -51,7 +51,7 @@ resource "azapi_resource" "aks_cluster" {
         {
           name              = "systempool"
           count             = 1
-          vmSize            = "Standard_DS2_v3"
+          vmSize            = "Standard_D2s_v3"
           mode              = "System"
           osType            = "Linux"
           type              = "VirtualMachineScaleSets"

--- a/quickstart/101-aks-network-isolated/main.tf
+++ b/quickstart/101-aks-network-isolated/main.tf
@@ -1,0 +1,74 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azapi" {}
+
+resource "random_string" "suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
+locals {
+  location            = "eastus"
+  resource_group_name = "rg-aks-network-isolated-${random_string.suffix.result}"
+  aks_name            = "aks-netisolated-${random_string.suffix.result}"
+  dns_prefix          = "aksnetiso${random_string.suffix.result}"
+}
+
+resource "azapi_resource" "resource_group" {
+  type     = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name     = local.resource_group_name
+  location = local.location
+}
+
+resource "azapi_resource" "aks_cluster" {
+  type      = "Microsoft.ContainerService/managedClusters@2025-08-01"
+  name      = local.aks_name
+  parent_id = azapi_resource.resource_group.id
+  location  = local.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  body = {
+    properties = {
+      dnsPrefix         = local.dns_prefix
+      kubernetesVersion = "1.30.3"
+      agentPoolProfiles = [
+        {
+          name              = "systempool"
+          count             = 1
+          vmSize            = "Standard_DS2_v2"
+          mode              = "System"
+          osType            = "Linux"
+          type              = "VirtualMachineScaleSets"
+          enableAutoScaling = false
+        }
+      ]
+      networkProfile = {
+        networkPlugin = "azure"
+        outboundType  = "none"
+      }
+      apiServerAccessProfile = {
+        enablePrivateCluster = true
+      }
+      bootstrapProfile = {
+        artifactSource = "Cache"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a Terraform quickstart for deploying a network-isolated Azure Kubernetes Service (AKS) cluster using AKS-managed artifact caching. The sample configures a private API server, Azure networking, outboundType = "none", and bootstrapProfile.artifactSource = "Cache" to support network-isolated cluster deployment without customer-managed ACR infrastructure.