### PR TITLE
Add AKS Defender for Containers quickstart

### DIFF
--- a/quickstart/101-aks-defender-containers/README.md
+++ b/quickstart/101-aks-defender-containers/README.md
@@ -1,0 +1,130 @@
+# Enable Microsoft Defender for Containers for AKS using Terraform
+
+This sample enables Microsoft Defender for Containers for an Azure Kubernetes Service (AKS) cluster using Terraform.
+
+Microsoft Defender for Containers helps protect Kubernetes environments by enabling security monitoring, vulnerability assessment, policy recommendations, and threat detection for container workloads.
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- An Azure subscription
+- Azure CLI installed and authenticated
+- Terraform installed
+- Permissions to create AKS clusters
+- Permissions to enable Microsoft Defender for Cloud plans at the subscription level
+
+> [!IMPORTANT]
+> Enabling the Defender for Containers plan applies at the subscription level. This can affect all supported container resources in the selected subscription.
+
+Verify your Azure session:
+
+```console
+az login
+az account show
+```
+
+## Terraform configuration
+
+The configuration in [main.tf](main.tf) performs the following actions:
+
+1. Creates a resource group.
+2. Creates a Log Analytics workspace for AKS security monitoring data.
+3. Enables the Defender for Containers plan at the subscription level.
+4. Creates an AKS cluster with Azure Policy, OIDC issuer, and Microsoft Defender security monitoring enabled.
+5. Outputs the resource group name, AKS cluster name, and Log Analytics workspace ID.
+
+## Initialize Terraform
+
+```console
+terraform init
+```
+
+## Format and validate the configuration
+
+```console
+terraform fmt
+terraform validate
+```
+
+## Preview and apply the configuration
+
+Preview the resources Terraform will create or change:
+
+```console
+terraform plan
+```
+
+Apply the configuration:
+
+```console
+terraform apply
+```
+
+When prompted, enter `yes`.
+
+## Verify the Defender for Containers plan
+
+Verify that the Defender for Containers plan is enabled at the subscription level:
+
+```console
+az security pricing show -n Containers -o table
+```
+
+The output should show the `Containers` plan with the `Standard` pricing tier:
+
+```text
+Name        PricingTier
+----------  ------------
+Containers  Standard
+```
+
+## Verify the AKS cluster configuration
+
+Check whether Azure Policy, OIDC, and Microsoft Defender security monitoring are enabled on the AKS cluster:
+
+```console
+az aks show \
+  --resource-group <resource-group-name> \
+  --name <aks-cluster-name> \
+  --query "{azurePolicy:addonProfiles.azurepolicy.enabled, oidc:oidcIssuerProfile.enabled, defender:securityProfile.defender}" \
+  -o json
+```
+
+For PowerShell, use:
+
+```powershell
+az aks show `
+  --resource-group <resource-group-name> `
+  --name <aks-cluster-name> `
+  --query "{azurePolicy:addonProfiles.azurepolicy.enabled, oidc:oidcIssuerProfile.enabled, defender:securityProfile.defender}" `
+  -o json
+```
+
+The output should show that Azure Policy is enabled, OIDC is enabled, and Microsoft Defender security monitoring is enabled:
+
+```json
+{
+  "azurePolicy": true,
+  "defender": {
+    "logAnalyticsWorkspaceResourceId": "<log-analytics-workspace-resource-id>",
+    "securityMonitoring": {
+      "enabled": true
+    }
+  },
+  "oidc": true
+}
+```
+
+## Clean up resources
+
+Delete the Azure resources created by this sample:
+
+```console
+terraform destroy
+```
+
+When prompted, enter `yes`.
+
+> [!IMPORTANT]
+> If the Defender for Containers pricing resource is managed by this Terraform configuration, destroying the configuration can change the subscription-level Containers plan. Confirm that you want to remove the plan before you run `terraform destroy`.

--- a/quickstart/101-aks-defender-containers/main.tf
+++ b/quickstart/101-aks-defender-containers/main.tf
@@ -71,6 +71,12 @@ resource "azurerm_kubernetes_cluster" "example" {
     name       = "system"
     node_count = 1
     vm_size    = "Standard_D2s_v3"
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
   }
 
   identity {

--- a/quickstart/101-aks-defender-containers/main.tf
+++ b/quickstart/101-aks-defender-containers/main.tf
@@ -39,10 +39,19 @@ resource "azurerm_security_center_subscription_pricing" "containers" {
 
   extension {
     name = "AgentlessVmScanning"
+    additional_extension_properties = {
+      ExclusionTags = jsonencode([])
+    }
   }
 
   extension {
     name = "ContainerSensor"
+    additional_extension_properties = {
+      AntiMalwareEnabled    = "True"
+      AutoProvisioning      = "True"
+      InstallationMethod    = "AKSAddon"
+      SecurityGatingEnabled = "True"
+    }
   }
 
   extension {

--- a/quickstart/101-aks-defender-containers/main.tf
+++ b/quickstart/101-aks-defender-containers/main.tf
@@ -1,0 +1,104 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  suffix   = substr(replace(data.azurerm_client_config.current.subscription_id, "-", ""), 0, 6)
+  location = "eastus"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-aks-defender-${local.suffix}"
+  location = local.location
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "law-aks-defender-${local.suffix}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_security_center_subscription_pricing" "containers" {
+  tier          = "Standard"
+  resource_type = "Containers"
+
+  extension {
+    name = "AgentlessVmScanning"
+  }
+
+  extension {
+    name = "ContainerSensor"
+  }
+
+  extension {
+    name = "AgentlessDiscoveryForKubernetes"
+  }
+
+  extension {
+    name = "ContainerRegistriesVulnerabilityAssessments"
+  }
+
+  extension {
+    name = "ContainerIntegrityContribution"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "example" {
+  name                              = "aks-defender-${local.suffix}"
+  location                          = azurerm_resource_group.example.location
+  resource_group_name               = azurerm_resource_group.example.name
+  dns_prefix                        = "aks-defender-${local.suffix}"
+  role_based_access_control_enabled = true
+  azure_policy_enabled              = true
+  oidc_issuer_enabled               = true
+
+  default_node_pool {
+    name       = "system"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  microsoft_defender {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  }
+
+  tags = {
+    Environment = "Test"
+    Purpose     = "DefenderForContainers"
+  }
+
+  depends_on = [
+    azurerm_security_center_subscription_pricing.containers
+  ]
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.example.name
+}
+
+output "aks_cluster_name" {
+  value = azurerm_kubernetes_cluster.example.name
+}
+
+output "log_analytics_workspace_id" {
+  value = azurerm_log_analytics_workspace.example.id
+}


### PR DESCRIPTION
Adds a Terraform quickstart sample for enabling Microsoft Defender for Containers on Azure Kubernetes Service (AKS).

This sample includes the Terraform configuration for enabling the Defender for Containers plan at the subscription level, creating an AKS cluster with Microsoft Defender security monitoring, and connecting the cluster to a Log Analytics workspace.

The README includes the original scenario’s prerequisites, deployment steps, verification steps, and resource cleanup guidance.