### PR TITLE
Copilot/add aks fleet managed namespaces quickstart

### DIFF
--- a/quickstart/101-aks-fleet-with-hub/README.MD
+++ b/quickstart/101-aks-fleet-with-hub/README.MD
@@ -1,0 +1,19 @@
+# Azure Kubernetes Fleet Manager with Hub Cluster (Fleet)
+
+This template deploys a fleet with a hub cluster provisioned, which is required for
+features that operate on the fleet's hub, such as managed namespaces.
+
+## Terraform resource types
+
+- [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)
+- [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/azapi_resource)
+
+## Variables
+
+| Name | Description | Default |
+|-|-|-|
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription. | rg |
+| `resource_group_location` | Location of the resource group. | eastus |
+| `fleet_name` | Name of the fleet resource. If left blank, this value is randomly generated. | "" |

--- a/quickstart/101-aks-fleet-with-hub/main.tf
+++ b/quickstart/101-aks-fleet-with-hub/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "fleet_rg" {
 }
 
 resource "random_string" "fleet_name" {
-  length  = 63
+  length  = 54
   lower   = true
   numeric = false
   special = false

--- a/quickstart/101-aks-fleet-with-hub/main.tf
+++ b/quickstart/101-aks-fleet-with-hub/main.tf
@@ -1,0 +1,44 @@
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "fleet_rg" {
+  name     = random_pet.rg_name.id
+  location = var.resource_group_location
+}
+
+resource "random_string" "fleet_name" {
+  length  = 63
+  lower   = true
+  numeric = false
+  special = false
+  upper   = false
+}
+
+locals {
+  fleet_name = coalesce(var.fleet_name != "" ? var.fleet_name : null, random_string.fleet_name.result)
+}
+
+# A fleet with a hub cluster is required for features such as managed namespaces,
+# which the plain azurerm_kubernetes_fleet_manager resource cannot provision because
+# its hub_profile attribute is deprecated and is no longer sent to the API.
+resource "azapi_resource" "fleet" {
+  type      = "Microsoft.ContainerService/fleets@2025-03-01"
+  name      = local.fleet_name
+  location  = azurerm_resource_group.fleet_rg.location
+  parent_id = azurerm_resource_group.fleet_rg.id
+
+  body = {
+    properties = {
+      hubProfile = {
+        dnsPrefix = local.fleet_name
+      }
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  response_export_values = ["name"]
+}

--- a/quickstart/101-aks-fleet-with-hub/outputs.tf
+++ b/quickstart/101-aks-fleet-with-hub/outputs.tf
@@ -1,0 +1,7 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.fleet_rg.name
+}
+
+output "fleet_name" {
+  value = azapi_resource.fleet.name
+}

--- a/quickstart/101-aks-fleet-with-hub/providers.tf
+++ b/quickstart/101-aks-fleet-with-hub/providers.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {}

--- a/quickstart/101-aks-fleet-with-hub/variables.tf
+++ b/quickstart/101-aks-fleet-with-hub/variables.tf
@@ -1,0 +1,15 @@
+variable "resource_group_location" {
+  type        = string
+  default     = "eastus"
+  description = "Location of the resource group"
+}
+variable "resource_group_name_prefix" {
+  type        = string
+  default     = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+variable "fleet_name" {
+  type        = string
+  description = "Name of the fleet resource. If left blank, this value is randomly generated."
+  default     = ""
+}

--- a/quickstart/201-aks-fleet-managed-namespaces/README.MD
+++ b/quickstart/201-aks-fleet-managed-namespaces/README.MD
@@ -1,0 +1,23 @@
+# Azure Kubernetes Fleet Manager - Managed Fleet Namespaces
+
+This template creates and configures a Managed Fleet Namespace for Azure Kubernetes Fleet Manager using Terraform. The configuration demonstrates how to centrally define namespace configuration, including labels, annotations, network policies, resource quotas, and placement across Fleet Manager member clusters.
+
+## Terraform resource types
+
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)
+- [azurerm_client_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/azapi_resource)
+  - Microsoft.ContainerService/fleets/managedNamespaces
+
+## Variables
+
+| Name | Description | Default |
+|-|-|-|
+| `resource_group_name` | Name of the resource group that contains the Fleet Manager. | null |
+| `fleet_name` | Name of the existing Azure Kubernetes Fleet Manager. | null |
+| `managed_namespace_name` | Name of the Managed Fleet Namespace. | `platform-ns` |
+| `tags` | Tags to apply to the Managed Fleet Namespace. | `{ environment = "demo", managed_by = "terraform" }` |
+
+## Example
+
+To see how to run this example, see [Terraform Azure Kubernetes Fleet Manager Managed Namespaces quickstart](https://learn.microsoft.com/en-us/azure/aks/fleet-namespaces).

--- a/quickstart/201-aks-fleet-managed-namespaces/TestRecord.md
+++ b/quickstart/201-aks-fleet-managed-namespaces/TestRecord.md
@@ -1,0 +1,7 @@
+# Test Record for 201-aks-fleet-managed-namespaces
+
+| Deployment | Result |
+|-|-|
+| Terraform Validate | Not tested |
+| Terraform Plan | Not tested |
+| Terraform Apply | Not tested |

--- a/quickstart/201-aks-fleet-managed-namespaces/TestRecord.md
+++ b/quickstart/201-aks-fleet-managed-namespaces/TestRecord.md
@@ -2,6 +2,6 @@
 
 | Deployment | Result |
 |-|-|
-| Terraform Validate | Not tested |
+| Terraform Validate | Passed |
 | Terraform Plan | Not tested |
 | Terraform Apply | Not tested |

--- a/quickstart/201-aks-fleet-managed-namespaces/main.tf
+++ b/quickstart/201-aks-fleet-managed-namespaces/main.tf
@@ -1,0 +1,56 @@
+data "azurerm_client_config" "current" {}
+
+data "azurerm_resource_group" "fleet_rg" {
+  name = var.resource_group_name
+}
+
+locals {
+  fleet_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.ContainerService/fleets/${var.fleet_name}"
+}
+
+resource "azapi_resource" "managed_fleet_namespace" {
+  type      = "Microsoft.ContainerService/fleets/managedNamespaces@2025-08-01-preview"
+  name      = var.managed_namespace_name
+  parent_id = local.fleet_id
+  location  = data.azurerm_resource_group.fleet_rg.location
+  tags      = var.tags
+
+  body = {
+    properties = {
+      adoptionPolicy = "Never"
+      deletePolicy   = "Keep"
+      managedNamespaceProperties = {
+        labels = {
+          team        = "platform"
+          environment = "demo"
+        }
+        annotations = {
+          owner                          = "aks-fleet-demo"
+          "app.kubernetes.io/managed-by" = "terraform"
+        }
+        defaultNetworkPolicy = {
+          ingress = "AllowAll"
+          egress  = "AllowAll"
+        }
+        defaultResourceQuota = {
+          cpuRequest    = "100m"
+          cpuLimit      = "500m"
+          memoryRequest = "128Mi"
+          memoryLimit   = "512Mi"
+        }
+      }
+      propagationPolicy = {
+        type = "Placement"
+        placementProfile = {
+          defaultClusterResourcePlacement = {
+            policy = {
+              placementType = "PickAll"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+

--- a/quickstart/201-aks-fleet-managed-namespaces/outputs.tf
+++ b/quickstart/201-aks-fleet-managed-namespaces/outputs.tf
@@ -1,0 +1,4 @@
+output "managed_fleet_namespace_id" {
+  description = "Resource ID of the Managed Fleet Namespace."
+  value       = azapi_resource.managed_fleet_namespace.id
+}

--- a/quickstart/201-aks-fleet-managed-namespaces/providers.tf
+++ b/quickstart/201-aks-fleet-managed-namespaces/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {}

--- a/quickstart/201-aks-fleet-managed-namespaces/terraform.tfvars.example
+++ b/quickstart/201-aks-fleet-managed-namespaces/terraform.tfvars.example
@@ -1,0 +1,3 @@
+resource_group_name    = "<resource-group-name>"
+fleet_name             = "<fleet-manager-name>"
+managed_namespace_name = "platform-ns"

--- a/quickstart/201-aks-fleet-managed-namespaces/variables.tf
+++ b/quickstart/201-aks-fleet-managed-namespaces/variables.tf
@@ -1,0 +1,29 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group that contains the Fleet Manager."
+}
+
+variable "fleet_name" {
+  type        = string
+  description = "Name of the existing Azure Kubernetes Fleet Manager."
+}
+
+variable "managed_namespace_name" {
+  type        = string
+  description = "Name of the Managed Fleet Namespace."
+  default     = "platform-ns"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", var.managed_namespace_name)) && length(var.managed_namespace_name) <= 63
+    error_message = "The managed namespace name must be 1-63 characters, use lowercase letters, numbers, or hyphens, and start and end with a lowercase letter or number."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the Managed Fleet Namespace."
+  default = {
+    environment = "demo"
+    managed_by  = "terraform"
+  }
+}

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -22,6 +22,7 @@ import (
 var speicalTests = map[string]func(*testing.T){
 	"quickstart/101-virtual-network-manager-create-management-group-scope": test101VirtualNetworkManagerCreateManagementGroupScope,
 	"quickstart/201-vmss-packer-jumpbox":                                   test201VmssPackerJumpbox,
+	"quickstart/201-aks-fleet-managed-namespaces":                          test201AksFleetManagedNamespaces,
 	"quickstart/202-machine-learning-moderately-secure-existing-VNet":      test202machineLearningModeratelySecureExistingVnet,
 	"quickstart/101-azure-netapp-files":                                    test101AzureNetappFiles,
 	"quickstart/101-azure-storage-actions-create-storage-task":             test101AzureStorageActionsCreateStorageTask,
@@ -234,6 +235,24 @@ func test101AzureStorageActionsCreateStorageTask(t *testing.T) {
 			"the response did not contain a body": "This API would response 202 accepted with empty body sometimes, just retry",
 		},
 	}, nil)
+}
+
+func test201AksFleetManagedNamespaces(t *testing.T) {
+	rootPath := filepath.Join("..", "..")
+	examplePath := filepath.Join("quickstart", "201-aks-fleet-managed-namespaces")
+	prequistePath := filepath.Join("quickstart", "101-aks-fleet-hubless")
+
+	helper.RunE2ETest(t, rootPath, prequistePath, terraform.Options{
+		Upgrade: true,
+	}, func(t *testing.T, output helper.TerraformOutput) {
+		helper.RunE2ETest(t, rootPath, examplePath, terraform.Options{
+			Upgrade: true,
+			Vars: map[string]interface{}{
+				"resource_group_name": output["resource_group_name"],
+				"fleet_name":          output["fleet_name"],
+			},
+		}, nil)
+	})
 }
 
 func removeDuplicates(s []string) []string {

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -240,7 +240,7 @@ func test101AzureStorageActionsCreateStorageTask(t *testing.T) {
 func test201AksFleetManagedNamespaces(t *testing.T) {
 	rootPath := filepath.Join("..", "..")
 	examplePath := filepath.Join("quickstart", "201-aks-fleet-managed-namespaces")
-	prequistePath := filepath.Join("quickstart", "101-aks-fleet-hubless")
+	prequistePath := filepath.Join("quickstart", "101-aks-fleet-with-hub")
 
 	helper.RunE2ETest(t, rootPath, prequistePath, terraform.Options{
 		Upgrade: true,


### PR DESCRIPTION
Adds a Terraform quickstart sample for Azure Kubernetes Fleet Manager Managed Fleet Namespaces. The sample includes the required provider configuration, variables, AzAPI managed namespace resource, outputs, example values, and supporting documentation. The implementation matches the authoritative Terraform source and has successfully passed Terraform formatting and validation checks.