### PR TITLE
Add AKS Fleet update strategy quickstart

### DIFF
--- a/quickstart/201-aks-fleet-update-strategy/README.md
+++ b/quickstart/201-aks-fleet-update-strategy/README.md
@@ -1,0 +1,30 @@
+# Azure Kubernetes Fleet Manager Update Strategy
+
+This template creates an Azure Kubernetes Fleet Manager and defines a reusable Fleet update strategy using Terraform. The update strategy demonstrates staged multi-cluster update configuration with two groups in the first stage, a wait period after the first stage, and one group in the second stage.
+
+## Terraform resource types
+
+- [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azurerm_kubernetes_fleet_manager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_fleet_manager)
+- [azurerm_kubernetes_fleet_update_strategy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_fleet_update_strategy)
+
+## Variables
+
+| Name | Description | Default |
+|-|-|-|
+| `location` | Azure region where the resource group and Fleet Manager are created. | `eastus` |
+| `resource_group_name` | Name of the resource group. If null, a unique name is generated. | `null` |
+| `fleet_name` | Name of the Azure Kubernetes Fleet Manager. If null, a unique name is generated. | `null` |
+| `update_strategy_name` | Name of the Fleet update strategy. | `example-update-strategy` |
+| `tags` | Tags to apply to created resources. | `{ environment = "demo", managed_by = "terraform" }` |
+
+## Example
+
+To run this example, review `terraform.tfvars.example`, then run:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```

--- a/quickstart/201-aks-fleet-update-strategy/TestRecord.md
+++ b/quickstart/201-aks-fleet-update-strategy/TestRecord.md
@@ -1,0 +1,9 @@
+# Test Record for 201-aks-fleet-update-strategy
+
+| Deployment | Result |
+|-|-|
+| Terraform Format | Passed |
+| Terraform Init | Passed |
+| Terraform Validate | Passed |
+| Terraform Plan | Not tested |
+| Terraform Apply | Not tested |

--- a/quickstart/201-aks-fleet-update-strategy/main.tf
+++ b/quickstart/201-aks-fleet-update-strategy/main.tf
@@ -1,0 +1,52 @@
+resource "random_string" "suffix" {
+  length  = 6
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
+}
+
+locals {
+  resource_group_name = coalesce(var.resource_group_name, "rg-fleet-update-strategy-${random_string.suffix.result}")
+  fleet_name          = coalesce(var.fleet_name, "fleet-update-strategy-${random_string.suffix.result}")
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = local.resource_group_name
+  location = var.location
+  tags     = var.tags
+}
+
+resource "azurerm_kubernetes_fleet_manager" "example" {
+  name                = local.fleet_name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tags                = var.tags
+}
+
+resource "azurerm_kubernetes_fleet_update_strategy" "example" {
+  name                        = var.update_strategy_name
+  kubernetes_fleet_manager_id = azurerm_kubernetes_fleet_manager.example.id
+
+  stage {
+    name = "stage-1"
+
+    group {
+      name = "group-1"
+    }
+
+    group {
+      name = "group-2"
+    }
+
+    after_stage_wait_in_seconds = 300
+  }
+
+  stage {
+    name = "stage-2"
+
+    group {
+      name = "group-3"
+    }
+  }
+}

--- a/quickstart/201-aks-fleet-update-strategy/outputs.tf
+++ b/quickstart/201-aks-fleet-update-strategy/outputs.tf
@@ -1,0 +1,19 @@
+output "resource_group_name" {
+  description = "Name of the created resource group."
+  value       = azurerm_resource_group.example.name
+}
+
+output "fleet_manager_id" {
+  description = "Resource ID of the Azure Kubernetes Fleet Manager."
+  value       = azurerm_kubernetes_fleet_manager.example.id
+}
+
+output "fleet_manager_name" {
+  description = "Name of the Azure Kubernetes Fleet Manager."
+  value       = azurerm_kubernetes_fleet_manager.example.name
+}
+
+output "update_strategy_id" {
+  description = "Resource ID of the Fleet update strategy."
+  value       = azurerm_kubernetes_fleet_update_strategy.example.id
+}

--- a/quickstart/201-aks-fleet-update-strategy/providers.tf
+++ b/quickstart/201-aks-fleet-update-strategy/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.77"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/quickstart/201-aks-fleet-update-strategy/terraform.tfvars.example
+++ b/quickstart/201-aks-fleet-update-strategy/terraform.tfvars.example
@@ -1,0 +1,9 @@
+location             = "eastus"
+resource_group_name  = null
+fleet_name           = null
+update_strategy_name = "example-update-strategy"
+
+tags = {
+  environment = "demo"
+  managed_by  = "terraform"
+}

--- a/quickstart/201-aks-fleet-update-strategy/variables.tf
+++ b/quickstart/201-aks-fleet-update-strategy/variables.tf
@@ -1,0 +1,32 @@
+variable "location" {
+  type        = string
+  description = "Azure region where the resource group and Fleet Manager are created."
+  default     = "eastus"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group. If null, a unique name is generated."
+  default     = null
+}
+
+variable "fleet_name" {
+  type        = string
+  description = "Name of the Azure Kubernetes Fleet Manager. If null, a unique name is generated."
+  default     = null
+}
+
+variable "update_strategy_name" {
+  type        = string
+  description = "Name of the Fleet update strategy."
+  default     = "example-update-strategy"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to created resources."
+  default = {
+    environment = "demo"
+    managed_by  = "terraform"
+  }
+}


### PR DESCRIPTION
Adds a Terraform quickstart for Azure Kubernetes Fleet Manager reusable update strategies, migrated from the local sample created for ADO 567237.

Summary:
- Creates `quickstart/201-aks-fleet-update-strategy`
- Preserves the AzureRM-native `azurerm_kubernetes_fleet_update_strategy` implementation
- Preserves the staged update behavior from the source sample: `stage-1` with `group-1` and `group-2`, `after_stage_wait_in_seconds = 300`, followed by `stage-2` with `group-3`
- Excludes local execution artifacts such as `.terraform`, state files, plan files, and backups

Validation:
- `terraform fmt -check -diff`
- `terraform init -backend=false -input=false`
- `terraform validate`