### PR TITLE
Add AKS Fleet Manager update automation quickstart (ADO 567031)

### DIFF
--- a/quickstart/201-aks-fleet-update-automation/README.md
+++ b/quickstart/201-aks-fleet-update-automation/README.md
@@ -1,0 +1,53 @@
+# Azure Kubernetes Fleet Manager Update Automation
+
+This template creates an Azure Kubernetes Fleet Manager and configures a Fleet auto-upgrade profile using Terraform. Auto-upgrade profiles automatically create and run updates across member clusters when new Kubernetes versions or node images become available.
+
+The profile defaults to the `Stable` channel with `Latest` node image selection and is enabled. Both the node image selection strategy (`Latest` or `Consistent`) and the enabled/disabled state are configurable through variables.
+
+> [!NOTE]
+> `Microsoft.ContainerService/fleets/autoUpgradeProfiles` is created through the AzAPI provider using the `2025-04-01-preview` API version, so `schema_validation_enabled` is set to `false`.
+
+## Terraform resource types
+
+- [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azurerm_kubernetes_fleet_manager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_fleet_manager)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/azapi_resource)
+  - Microsoft.ContainerService/fleets/autoUpgradeProfiles
+
+## Variables
+
+| Name | Description | Default |
+|-|-|-|
+| `location` | Azure region where the resource group and Fleet Manager are created. | `eastus` |
+| `resource_group_name` | Name of the resource group. If null, a unique name is generated. | `null` |
+| `fleet_name` | Name of the Azure Kubernetes Fleet Manager. If null, a unique name is generated. | `null` |
+| `auto_upgrade_profile_name` | Name of the Fleet auto-upgrade profile. If null, a unique name is generated. | `null` |
+| `auto_upgrade_channel` | Auto-upgrade channel used by the profile. | `Stable` |
+| `target_kubernetes_version` | Target Kubernetes version in `major.minor` format. Required when `auto_upgrade_channel` is `TargetKubernetesVersion`; otherwise leave null. | `null` |
+| `node_image_selection` | Node image selection type (`Latest` or `Consistent`). | `Latest` |
+| `auto_upgrade_disabled` | Set to true to stop the profile from creating new automatic update runs. | `false` |
+| `long_term_support` | Whether the profile targets long-term support Kubernetes versions. Only supported on the `TargetKubernetesVersion` channel. | `false` |
+| `tags` | Tags to apply to created resources. | `{ environment = "demo", managed_by = "terraform" }` |
+
+## Example
+
+To run this example, review `terraform.tfvars.example`, then run:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+To wait for the same node image version to be available across all member cluster regions, set `node_image_selection = "Consistent"` and reapply. To stop the profile from creating new update runs, set `auto_upgrade_disabled = true` and reapply.
+
+To pin the fleet to a specific Kubernetes version, set `auto_upgrade_channel = "TargetKubernetesVersion"` and supply `target_kubernetes_version` in `major.minor` format:
+
+```hcl
+auto_upgrade_channel      = "TargetKubernetesVersion"
+target_kubernetes_version = "1.31"
+long_term_support         = true
+```
+
+`targetKubernetesVersion` is sent to the API only on the `TargetKubernetesVersion` channel and is omitted for `Rapid`, `Stable`, and `NodeImage`. `long_term_support` can only be enabled on the `TargetKubernetesVersion` channel.

--- a/quickstart/201-aks-fleet-update-automation/TestRecord.md
+++ b/quickstart/201-aks-fleet-update-automation/TestRecord.md
@@ -1,0 +1,18 @@
+# Test Record for 201-aks-fleet-update-automation
+
+| Deployment | Result |
+|-|-|
+| Terraform Format | Passed |
+| Terraform Init | Passed |
+| Terraform Validate | Passed |
+| Terraform Plan | Not run |
+| Terraform Apply | Not run |
+| Terraform Destroy | Not run |
+
+`terraform fmt`, `terraform fmt -check -recursive`, `terraform init`, and `terraform validate` all
+completed successfully using azurerm v4.81.0, azapi v2.12.0, and random v3.9.0.
+
+`terraform plan`, `terraform apply`, and `terraform destroy` were not rerun during this migration
+because the `terraform-docs` subscription's Azure AD tenant is expired, so the AzureRM provider
+could not acquire an access token. These steps still need to be validated against a live
+subscription.

--- a/quickstart/201-aks-fleet-update-automation/main.tf
+++ b/quickstart/201-aks-fleet-update-automation/main.tf
@@ -1,0 +1,53 @@
+resource "random_string" "suffix" {
+  length  = 5
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
+}
+
+locals {
+  resource_group_name       = coalesce(var.resource_group_name, "rg-fleet-update-${random_string.suffix.result}")
+  fleet_name                = coalesce(var.fleet_name, "fleet-update-${random_string.suffix.result}")
+  auto_upgrade_profile_name = coalesce(var.auto_upgrade_profile_name, "stable-profile-${random_string.suffix.result}")
+
+  # targetKubernetesVersion is only valid on the TargetKubernetesVersion channel.
+  auto_upgrade_properties = merge(
+    {
+      channel         = var.auto_upgrade_channel
+      disabled        = var.auto_upgrade_disabled
+      longTermSupport = var.long_term_support
+      nodeImageSelection = {
+        type = var.node_image_selection
+      }
+    },
+    var.auto_upgrade_channel == "TargetKubernetesVersion" ? {
+      targetKubernetesVersion = var.target_kubernetes_version
+    } : {}
+  )
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = local.resource_group_name
+  location = var.location
+  tags     = var.tags
+}
+
+resource "azurerm_kubernetes_fleet_manager" "example" {
+  name                = local.fleet_name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tags                = var.tags
+}
+
+# autoUpgradeProfiles is only available on the preview API version, which requires schema validation to be disabled.
+resource "azapi_resource" "auto_upgrade_profile" {
+  type                      = "Microsoft.ContainerService/fleets/autoUpgradeProfiles@2025-04-01-preview"
+  name                      = local.auto_upgrade_profile_name
+  parent_id                 = azurerm_kubernetes_fleet_manager.example.id
+  schema_validation_enabled = false
+
+  body = {
+    properties = local.auto_upgrade_properties
+  }
+}

--- a/quickstart/201-aks-fleet-update-automation/outputs.tf
+++ b/quickstart/201-aks-fleet-update-automation/outputs.tf
@@ -1,0 +1,24 @@
+output "resource_group_name" {
+  description = "Name of the created resource group."
+  value       = azurerm_resource_group.example.name
+}
+
+output "fleet_manager_name" {
+  description = "Name of the Azure Kubernetes Fleet Manager."
+  value       = azurerm_kubernetes_fleet_manager.example.name
+}
+
+output "fleet_manager_id" {
+  description = "Resource ID of the Azure Kubernetes Fleet Manager."
+  value       = azurerm_kubernetes_fleet_manager.example.id
+}
+
+output "auto_upgrade_profile_name" {
+  description = "Name of the Fleet auto-upgrade profile."
+  value       = azapi_resource.auto_upgrade_profile.name
+}
+
+output "auto_upgrade_profile_id" {
+  description = "Resource ID of the Fleet auto-upgrade profile."
+  value       = azapi_resource.auto_upgrade_profile.id
+}

--- a/quickstart/201-aks-fleet-update-automation/providers.tf
+++ b/quickstart/201-aks-fleet-update-automation/providers.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {
+}

--- a/quickstart/201-aks-fleet-update-automation/terraform.tfvars.example
+++ b/quickstart/201-aks-fleet-update-automation/terraform.tfvars.example
@@ -1,0 +1,22 @@
+location = "eastus"
+
+# Leave null to use auto-generated unique names.
+resource_group_name       = null
+fleet_name                = null
+auto_upgrade_profile_name = null
+
+# Auto-upgrade profile configuration.
+auto_upgrade_channel  = "Stable" # Rapid, Stable, NodeImage, TargetKubernetesVersion
+node_image_selection  = "Latest" # Latest or Consistent
+auto_upgrade_disabled = false
+
+# Required only when auto_upgrade_channel = "TargetKubernetesVersion"; leave null otherwise.
+target_kubernetes_version = null # For example, "1.31"
+
+# Only supported on the TargetKubernetesVersion channel.
+long_term_support = false
+
+tags = {
+  environment = "demo"
+  managed_by  = "terraform"
+}

--- a/quickstart/201-aks-fleet-update-automation/variables.tf
+++ b/quickstart/201-aks-fleet-update-automation/variables.tf
@@ -1,0 +1,87 @@
+variable "location" {
+  type        = string
+  description = "Azure region where the resource group and Fleet Manager are created."
+  default     = "eastus"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group. If null, a unique name is generated."
+  default     = null
+}
+
+variable "fleet_name" {
+  type        = string
+  description = "Name of the Azure Kubernetes Fleet Manager. If null, a unique name is generated."
+  default     = null
+}
+
+variable "auto_upgrade_profile_name" {
+  type        = string
+  description = "Name of the Fleet auto-upgrade profile. If null, a unique name is generated."
+  default     = null
+}
+
+variable "auto_upgrade_channel" {
+  type        = string
+  description = "Auto-upgrade channel used by the profile."
+  default     = "Stable"
+
+  validation {
+    condition     = contains(["Rapid", "Stable", "NodeImage", "TargetKubernetesVersion"], var.auto_upgrade_channel)
+    error_message = "Auto-upgrade channel must be one of: Rapid, Stable, NodeImage, TargetKubernetesVersion."
+  }
+}
+
+variable "target_kubernetes_version" {
+  type        = string
+  description = "Target Kubernetes version in major.minor format, for example 1.31. Required when auto_upgrade_channel is TargetKubernetesVersion; otherwise leave null."
+  default     = null
+
+  validation {
+    condition     = var.target_kubernetes_version == null || can(regex("^[0-9]+\\.[0-9]+$", var.target_kubernetes_version))
+    error_message = "Target Kubernetes version must be in major.minor format, for example 1.31."
+  }
+
+  validation {
+    condition     = var.auto_upgrade_channel != "TargetKubernetesVersion" || var.target_kubernetes_version != null
+    error_message = "Target Kubernetes version is required when auto_upgrade_channel is TargetKubernetesVersion."
+  }
+}
+
+variable "node_image_selection" {
+  type        = string
+  description = "Node image selection type. Latest uses the newest image per region; Consistent waits for the same image version across all member regions."
+  default     = "Latest"
+
+  validation {
+    condition     = contains(["Latest", "Consistent"], var.node_image_selection)
+    error_message = "Node image selection must be either Latest or Consistent."
+  }
+}
+
+variable "auto_upgrade_disabled" {
+  type        = bool
+  description = "Set to true to stop the profile from creating new automatic update runs. In-progress update runs aren't cancelled."
+  default     = false
+}
+
+variable "long_term_support" {
+  type        = bool
+  description = "Whether the profile targets long-term support Kubernetes versions. Only supported on the TargetKubernetesVersion channel."
+  default     = false
+
+  validation {
+    condition     = !var.long_term_support || var.auto_upgrade_channel == "TargetKubernetesVersion"
+    error_message = "Long-term support can only be enabled when auto_upgrade_channel is TargetKubernetesVersion."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to created resources."
+  default = {
+    environment = "demo"
+    managed_by  = "terraform"
+  }
+}


### PR DESCRIPTION
## Description

Migrates the AKS Fleet update-automation Terraform sample into this repository as a new quickstart at `quickstart/201-aks-fleet-update-automation`.

The sample creates an Azure Kubernetes Fleet Manager and configures a Fleet **auto-upgrade profile** (`Microsoft.ContainerService/fleets/autoUpgradeProfiles`) through the AzAPI provider, so Kubernetes and node image upgrades are created and run automatically across member clusters.

Work item: **ADO 567031 - Automate Kubernetes and Node Image Upgrades for Multiple Clusters using Azure Kubernetes Fleet Manager**

### What's included

| File | Purpose |
|-|-|
| `providers.tf` | Terraform and provider requirements (azurerm, azapi, random) |
| `main.tf` | Resource group, `azurerm_kubernetes_fleet_manager`, and the AzAPI auto-upgrade profile |
| `variables.tf` | Channel, node image selection, target Kubernetes version, LTS, disabled state, naming, tags |
| `outputs.tf` | Resource group, Fleet Manager, and auto-upgrade profile names/IDs |
| `terraform.tfvars.example` | Example values |
| `README.md` | Description, resource types, variables table, usage |
| `TestRecord.md` | Test results |

### Notes for reviewers

- **Not a duplicate of `201-aks-clusters-fleet-manager-azapi`.** That sample provisions three member AKS clusters plus a fleet, members, and an update strategy, and attaches an auto-upgrade profile as one piece of a larger topology. This sample is focused solely on update automation: it uses `azurerm_kubernetes_fleet_manager` (hubless) as the profile's parent and exercises the auto-upgrade options themselves - `channel`, `nodeImageSelection` (`Latest` vs `Consistent`), `longTermSupport`, `targetKubernetesVersion`, and the enabled/disabled lifecycle. It is also distinct from `201-aks-fleet-update-strategy`, which covers staged update strategies and contains no auto-upgrade profile.
- `autoUpgradeProfiles` is only exposed on the `2025-04-01-preview` API version, so the AzAPI resource sets `schema_validation_enabled = false`. This is called out in the README.
- `targetKubernetesVersion` is included in the request body **only** when `auto_upgrade_channel = "TargetKubernetesVersion"` and is omitted for `Rapid`, `Stable`, and `NodeImage`. Variable validation requires it in `major.minor` format on that channel, and restricts `long_term_support = true` to that channel as well. These cross-variable validations require Terraform >= 1.9, which `providers.tf` pins.

### Testing

| Step | Result |
|-|-|
| `terraform fmt` | Passed |
| `terraform fmt -check -recursive` | Passed |
| `terraform init` | Passed (azurerm v4.81.0, azapi v2.12.0, random v3.9.0) |
| `terraform validate` | Passed |
| `terraform plan` | Not run |
| `terraform apply` | Not run |
| `terraform destroy` | Not run |

`plan`, `apply`, and `destroy` were **not** rerun during this migration because the Azure AD tenant behind the `terraform-docs` subscription is expired and the AzureRM provider could not acquire an access token. This is recorded in `TestRecord.md` and still needs validation against a live subscription.

### Out of scope

The corresponding Learn quickstart article is not part of this PR and will be submitted separately to the docs repository.
