### PR TITLE
Add AKS Azure Policy quickstart

### DIFF
--- a/quickstart/101-aks-use-azure-policy/README.md
+++ b/quickstart/101-aks-use-azure-policy/README.md
@@ -107,6 +107,16 @@ resource "azurerm_resource_group_policy_assignment" "aks_pod_security_baseline" 
 }
 ```
 
+## Output the AKS cluster name
+The following output surfaces the name of the AKS cluster that the policy assignment targets, for reference.
+
+```hcl
+output "aks_cluster_name" {
+ description = "Name of the AKS cluster targeted by this policy assignment."
+ value       = var.aks_cluster_name
+}
+```
+
 ## Initialize the Terraform configuration
 Run `terraform init` to initialize the Terraform working directory and download the required provider plugins.
 

--- a/quickstart/101-aks-use-azure-policy/README.md
+++ b/quickstart/101-aks-use-azure-policy/README.md
@@ -68,18 +68,14 @@ variable "aks_cluster_name" {
 }
 ```
 
-## Reference the existing AKS cluster
-The following data sources retrieve information about the existing resource group and AKS cluster.
+## Reference the existing resource group
+The following data source retrieves information about the existing resource group that contains the AKS cluster.
 
-Terraform uses these resources to reference infrastructure that already exists in Azure instead of creating new resources.
+Terraform uses this data source to reference infrastructure that already exists in Azure instead of creating new resources. The policy assignment is scoped to the resource group, so the AKS cluster itself doesn't need to be looked up.
 
 ```hcl
 data "azurerm_resource_group" "aks" {
  name = var.resource_group_name
-}
-data "azurerm_kubernetes_cluster" "aks" {
- name                = var.aks_cluster_name
- resource_group_name = data.azurerm_resource_group.aks.name
 }
 ```
 

--- a/quickstart/101-aks-use-azure-policy/README.md
+++ b/quickstart/101-aks-use-azure-policy/README.md
@@ -1,0 +1,183 @@
+## Configure Azure Policy for an existing AKS cluster using Terraform
+
+This article shows how to assign a built-in Azure Policy initiative to an existing Azure Kubernetes Service (AKS) cluster using Terraform.
+In this example, you assign the following built-in initiative:
+
+- Kubernetes cluster pod security baseline standards for Linux-based workloads
+The policy effect is configured as `Deny` to prevent non-compliant workloads from being deployed to the cluster.
+
+## Before you begin
+
+You need the following resources installed and configured before you begin:
+
+- An Azure subscription. If you don't have an Azure subscription, you can create a free account.
+- Terraform version 1.6.0 or later.
+- Azure CLI version 2.0.81 or later.
+- Kubectl installed and configured.
+- An existing AKS cluster.
+- The Azure Policy add-on enabled on the AKS cluster.
+Create a directory for the Terraform configuration.
+
+```bash
+mkdir aks-use-azure-policy
+cd aks-use-azure-policy
+```
+
+## Create the Terraform configuration
+Create a file named `main.tf`.
+
+```bash
+touch main.tf
+```
+
+Open the `main.tf` file and add the following configuration.
+
+## Configure the Terraform provider
+The following configuration:
+
+- Defines the Terraform version
+- Configures the AzureRM provider
+- Enables Azure provider features required for resource management
+
+```hcl
+terraform {
+ required_version = ">= 1.6.0"
+ required_providers {
+   azurerm = {
+     source  = "hashicorp/azurerm"
+     version = "~> 4.0"
+   }
+ }
+}
+provider "azurerm" {
+ features {}
+}
+```
+
+## Define input variables
+The following variables allow you to provide the name of the existing resource group and AKS cluster during deployment.
+
+```hcl
+variable "resource_group_name" {
+ description = "Name of the resource group that contains the existing AKS cluster."
+ type        = string
+}
+variable "aks_cluster_name" {
+ description = "Name of the existing AKS cluster."
+ type        = string
+}
+```
+
+## Reference the existing AKS cluster
+The following data sources retrieve information about the existing resource group and AKS cluster.
+
+Terraform uses these resources to reference infrastructure that already exists in Azure instead of creating new resources.
+
+```hcl
+data "azurerm_resource_group" "aks" {
+ name = var.resource_group_name
+}
+data "azurerm_kubernetes_cluster" "aks" {
+ name                = var.aks_cluster_name
+ resource_group_name = data.azurerm_resource_group.aks.name
+}
+```
+
+## Retrieve the built-in Azure Policy initiative
+The following data source retrieves the built-in Azure Policy initiative for Kubernetes pod security baseline standards.
+
+```hcl
+data "azurerm_policy_set_definition" "aks_pod_security_baseline" {
+ display_name = "Kubernetes cluster pod security baseline standards for Linux-based workloads"
+}
+```
+
+## Assign the Azure Policy initiative
+The following resource assigns the built-in Azure Policy initiative to the resource group that contains the AKS cluster.
+
+The policy effect is configured as `Deny`, which blocks workloads that violate the defined policy rules.
+
+```hcl
+resource "azurerm_resource_group_policy_assignment" "aks_pod_security_baseline" {
+ name                 = "aks-pod-security-baseline"
+ display_name         = "Kubernetes cluster pod security baseline standards for Linux-based workloads"
+ resource_group_id    = data.azurerm_resource_group.aks.id
+ policy_definition_id = data.azurerm_policy_set_definition.aks_pod_security_baseline.id
+ parameters = jsonencode({
+   effect = {
+     value = "Deny"
+   }
+ })
+}
+```
+
+## Initialize the Terraform configuration
+Run `terraform init` to initialize the Terraform working directory and download the required provider plugins.
+
+```bash
+terraform init
+```
+
+## Format and validate the configuration
+Run `terraform fmt` to format the Terraform configuration.
+
+```bash
+terraform fmt
+```
+
+Run `terraform validate` to validate the Terraform configuration syntax.
+
+```bash
+terraform validate
+```
+
+## Apply the Terraform configuration
+Before deploying the configuration, provide values for the following variables:
+
+- `resource_group_name`
+- `aks_cluster_name`
+
+Run `terraform apply` to deploy the Azure Policy assignment.
+
+```bash
+terraform apply
+```
+
+When prompted, enter `yes` to confirm the deployment.
+
+## Verify the Azure Policy installation
+After deployment completes, verify that the Azure Policy components are running in the AKS cluster.
+
+```bash
+kubectl get pods -n kube-system
+```
+
+Verify that the Gatekeeper constraint templates were installed successfully.
+
+```bash
+kubectl get constrainttemplates
+```
+
+## Test the Azure Policy assignment
+Create a file named `privileged-pod.yaml`.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+ name: privileged-pod
+spec:
+ containers:
+ - name: nginx
+   image: nginx
+   securityContext:
+     privileged: true
+```
+
+Apply the manifest to the cluster.
+
+```bash
+kubectl apply -f privileged-pod.yaml
+```
+
+The deployment should fail because the Azure Policy assignment denies privileged containers that violate the configured pod security baseline standards.

--- a/quickstart/101-aks-use-azure-policy/main.tf
+++ b/quickstart/101-aks-use-azure-policy/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+provider "azurerm" {
+  features {}
+}
+variable "resource_group_name" {
+  description = "Name of the resource group that contains the existing AKS cluster."
+  type = string
+}
+variable "aks_cluster_name" {
+  description = "Name of the existing AKS cluster."
+  type = string
+}
+data "azurerm_resource_group" "aks" {
+  name = var.resource_group_name
+}
+data "azurerm_kubernetes_cluster" "aks" {
+  name = var.aks_cluster_name
+  resource_group_name = data.azurerm_resource_group.aks.name
+}
+data "azurerm_policy_set_definition" "aks_pod_security_baseline" {
+  display_name = "Kubernetes cluster pod security baseline standards for Linux-based workloads"
+}
+resource "azurerm_resource_group_policy_assignment" "aks_pod_security_baseline" {
+  name = "aks-pod-security-baseline"
+  display_name = "Kubernetes cluster pod security baseline standards for Linux-based workloads"
+  resource_group_id = data.azurerm_resource_group.aks.id
+  policy_definition_id = data.azurerm_policy_set_definition.aks_pod_security_baseline.id
+  parameters = jsonencode({
+    effect = {
+      value = "Deny"
+    }
+  })
+}
+ 

--- a/quickstart/101-aks-use-azure-policy/main.tf
+++ b/quickstart/101-aks-use-azure-policy/main.tf
@@ -21,10 +21,6 @@ variable "aks_cluster_name" {
 data "azurerm_resource_group" "aks" {
   name = var.resource_group_name
 }
-data "azurerm_kubernetes_cluster" "aks" {
-  name = var.aks_cluster_name
-  resource_group_name = data.azurerm_resource_group.aks.name
-}
 data "azurerm_policy_set_definition" "aks_pod_security_baseline" {
   display_name = "Kubernetes cluster pod security baseline standards for Linux-based workloads"
 }

--- a/quickstart/101-aks-use-azure-policy/main.tf
+++ b/quickstart/101-aks-use-azure-policy/main.tf
@@ -35,4 +35,7 @@ resource "azurerm_resource_group_policy_assignment" "aks_pod_security_baseline" 
     }
   })
 }
- 
+output "aks_cluster_name" {
+  description = "Name of the AKS cluster targeted by this policy assignment."
+  value = var.aks_cluster_name
+}

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -25,6 +25,7 @@ var speicalTests = map[string]func(*testing.T){
 	"quickstart/202-machine-learning-moderately-secure-existing-VNet":      test202machineLearningModeratelySecureExistingVnet,
 	"quickstart/101-azure-netapp-files":                                    test101AzureNetappFiles,
 	"quickstart/101-azure-storage-actions-create-storage-task":             test101AzureStorageActionsCreateStorageTask,
+	"quickstart/101-aks-use-azure-policy":                                  test101AksUseAzurePolicy,
 }
 
 func Test_Quickstarts(t *testing.T) {
@@ -219,6 +220,24 @@ func test202machineLearningModeratelySecureExistingVnet(t *testing.T) {
 				"privatelink_blob_core_windows_net_resource_id": output["privatelink_blob_core_windows_net_resource_id"],
 				"privatelink_file_core_windows_net_resource_id": output["privatelink_file_core_windows_net_resource_id"],
 				"privatelink_vaultcore_azure_net_resource_id":   output["privatelink_vaultcore_azure_net_resource_id"],
+			},
+		}, nil)
+	})
+}
+
+func test101AksUseAzurePolicy(t *testing.T) {
+	rootPath := filepath.Join("..", "..")
+	prequisitePath := filepath.Join("quickstart", "101-aks-automatic")
+	examplePath := filepath.Join("quickstart", "101-aks-use-azure-policy")
+
+	helper.RunE2ETest(t, rootPath, prequisitePath, terraform.Options{
+		Upgrade: true,
+	}, func(t *testing.T, output helper.TerraformOutput) {
+		helper.RunE2ETest(t, rootPath, examplePath, terraform.Options{
+			Upgrade: true,
+			Vars: map[string]interface{}{
+				"resource_group_name": output["resource_group_name"],
+				"aks_cluster_name":    output["cluster_name"],
 			},
 		}, nil)
 	})


### PR DESCRIPTION
Summary
- Adds a Terraform quickstart for assigning the built-in Azure Policy pod security baseline initiative to an existing AKS cluster.
- Includes the Terraform configuration and a README with deployment and validation instructions.
- Requires an existing AKS cluster with the Azure Policy add-on enabled.

Related work item:
[568336](https://dev.azure.com/msft-skilling/Content/_workitems/edit/568336)
 