### PR TITLE
Add Azure Monitor Health Models AzAPI quickstart

### DIFF
--- a/quickstart/101-health-model/main.tf
+++ b/quickstart/101-health-model/main.tf
@@ -1,12 +1,15 @@
+# Create a random suffix for the resource names.
 resource "random_pet" "name" {
   length = 2
 }
 
+# Create a resource group for the health model.
 resource "azurerm_resource_group" "example" {
   name     = "${var.resource_group_name_prefix}-${random_pet.name.id}"
   location = var.resource_group_location
 }
 
+# Create a health model with a system-assigned managed identity.
 resource "azapi_resource" "health_model" {
   type      = "Microsoft.CloudHealth/healthmodels@2026-05-01-preview"
   name      = "${var.health_model_name_prefix}-${random_pet.name.id}"

--- a/quickstart/101-health-model/main.tf
+++ b/quickstart/101-health-model/main.tf
@@ -1,0 +1,27 @@
+resource "random_pet" "name" {
+  length = 2
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.resource_group_name_prefix}-${random_pet.name.id}"
+  location = var.resource_group_location
+}
+
+resource "azapi_resource" "health_model" {
+  type      = "Microsoft.CloudHealth/healthmodels@2026-05-01-preview"
+  name      = "${var.health_model_name_prefix}-${random_pet.name.id}"
+  parent_id = azurerm_resource_group.example.id
+  location  = azurerm_resource_group.example.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  body = {
+    properties = {}
+  }
+
+  tags = {
+    environment = "example"
+  }
+}

--- a/quickstart/101-health-model/outputs.tf
+++ b/quickstart/101-health-model/outputs.tf
@@ -1,0 +1,19 @@
+output "resource_group_name" {
+  description = "Name of the resource group that contains the health model."
+  value       = azurerm_resource_group.example.name
+}
+
+output "health_model_name" {
+  description = "Name of the health model."
+  value       = azapi_resource.health_model.name
+}
+
+output "health_model_id" {
+  description = "Resource ID of the health model."
+  value       = azapi_resource.health_model.id
+}
+
+output "health_model_location" {
+  description = "Azure region where the health model is deployed."
+  value       = azapi_resource.health_model.location
+}

--- a/quickstart/101-health-model/providers.tf
+++ b/quickstart/101-health-model/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azapi" {}
+
+provider "azurerm" {
+  features {}
+}

--- a/quickstart/101-health-model/readme.md
+++ b/quickstart/101-health-model/readme.md
@@ -1,0 +1,27 @@
+# Azure Monitor health model (AzAPI provider)
+
+This template demonstrates how to deploy an Azure Monitor health model with a system-assigned managed identity into a resource group with a random name beginning with `rg-health-model`.
+
+The health model is declared with the AzAPI provider's [`azapi_resource`](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) and the `Microsoft.CloudHealth/healthmodels@2026-05-01-preview` API. The AzureRM provider doesn't currently expose a native Health Models resource.
+
+## Terraform resource types
+
+- [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)
+- [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
+- [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)
+
+## Variables
+
+| Name | Description | Default |
+|-|-|-|
+| `resource_group_location` | Location of the resource group and health model. | swedencentral |
+| `resource_group_name_prefix` | Prefix of the resource group name that's combined with a random ID. | rg-health-model |
+| `health_model_name_prefix` | Prefix of the health model name that's combined with a random ID. | health-model |
+
+## Example
+
+```console
+terraform init -upgrade
+terraform plan -out main.tfplan
+terraform apply main.tfplan
+```

--- a/quickstart/101-health-model/variables.tf
+++ b/quickstart/101-health-model/variables.tf
@@ -1,0 +1,17 @@
+variable "resource_group_location" {
+  type        = string
+  default     = "swedencentral"
+  description = "Location of the resource group and health model."
+}
+
+variable "resource_group_name_prefix" {
+  type        = string
+  default     = "rg-health-model"
+  description = "Prefix of the resource group name that's combined with a random ID so the name is unique in your Azure subscription."
+}
+
+variable "health_model_name_prefix" {
+  type        = string
+  default     = "health-model"
+  description = "Prefix of the health model name that's combined with a random ID so the name is unique in your Azure subscription."
+}


### PR DESCRIPTION
## Summary

Adds a Terraform sample that deploys a self-contained Azure Monitor health model through the AzAPI provider and the current `Microsoft.CloudHealth/healthmodels@2026-05-01-preview` API. The AzureRM provider doesn't currently expose a native Health Models resource.

The Health Models team confirmed through Megan Goode that it can support AzAPI as the current Terraform path for GA. Hansjoerg Scherer recommended Storage and Key Vault resource entities beneath an abstract parent, with the Health Model's system-assigned identity. André Bossard reviewed and corrected the final graph, required role, and resource ordering. Native AzureRM support remains future work.

## Maintainer action needed

The repository's E2E workflow doesn't execute deployment tests for fork heads. A maintainer needs to move this contribution through an upstream release branch and open a release-to-`master` PR so the protected `e2e-check` can run. This follows the workflow's linked release-branch process and the precedent in [PR #479](https://github.com/Azure/terraform/pull/479) and [release PR #480](https://github.com/Azure/terraform/pull/480).

## Changes

- Creates a randomly named disposable resource group, Storage account, and Key Vault with AzureRM.
- Creates a Health Model with AzAPI and a system-assigned managed identity.
- Assigns Reader to the Health Model identity at resource-group scope.
- Creates a managed-identity authentication setting.
- Creates Storage and Key Vault resource entities with Availability metric signals.
- Sets the Key Vault entity impact to `Limited`.
- Creates an abstract application entity.
- Connects the Health Model root to the application and the application to both resource entities.
- Exposes the resource group, Health Model, Storage account, and Key Vault names as outputs.

## Validation

Tested with Terraform 1.15.8, AzAPI 2.12.0, AzureRM 4.81.0, and Random 3.9.0.

- `terraform fmt -check`: passed.
- `terraform validate`: passed with zero warnings.
- `terraform plan`: 13 resources to add, 0 to change, and 0 to destroy.
- `terraform apply`: passed with all 13 resources created.
- Azure API verification: Health Model provisioning succeeded with a system-assigned identity.
- Authentication verification: `ManagedIdentity` with `SystemAssigned`.
- Entity verification: abstract application, Storage, and Key Vault entities were created, in addition to the automatic Health Model root entity.
- Signal verification: both resource entities use the published `Availability` metric with `Percent` and `Average`.
- Relationship verification: the Health Model root connects to the application, which connects to both resource entities.
- Authorization verification: the Health Model identity has Reader at resource-group scope.
- Idempotence plan after apply: no changes.
- Destroy apply: all 13 resources destroyed.
- Independent resource-group deletion and empty-state checks: passed.

Related documentation work: https://github.com/MicrosoftDocs/azure-monitor-docs-pr/pull/5252

Related work item: https://dev.azure.com/msft-skilling/Content/_workitems/edit/629740